### PR TITLE
added flag to rename EXML files to MXML files only 

### DIFF
--- a/exml/exml-maven-plugin/pom.xml
+++ b/exml/exml-maven-plugin/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
       <scope>test</scope>

--- a/exml/exml-maven-plugin/src/main/java/net/jangaroo/exml/mojo/ExmlToMxmlMojo.java
+++ b/exml/exml-maven-plugin/src/main/java/net/jangaroo/exml/mojo/ExmlToMxmlMojo.java
@@ -8,9 +8,15 @@ import net.jangaroo.exml.config.ExmlConfiguration;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static java.lang.String.format;
+import static org.apache.commons.io.FileUtils.listFiles;
+import static org.apache.commons.io.FileUtils.moveFile;
+import static org.apache.commons.io.FilenameUtils.getBaseName;
 
 /**
  * A Mojo to compile EXML sources to AS3 sources into target/generated-sources/joo in phase generate-sources.
@@ -29,8 +35,27 @@ public class ExmlToMxmlMojo extends AbstractExmlMojo {
    */
   private File testSourceDirectory;
 
+  /**
+   * Set this to 'true' to rename EXML files to MXML files only and to skip the actual conversion. This allows to give
+   * a hint to SCM systems like Git about the renaming and then run the actual conversion in a second step.
+   *
+   * @parameter expression="${renameOnly}"
+   */
+  private boolean renameOnly;
+
   @Override
   public void execute() throws MojoExecutionException {
+    if (renameOnly) {
+      getLog().info("Renaming EXML files to MXML files");
+      try {
+        renameFiles(getSourceDirectory());
+        renameFiles(testSourceDirectory);
+      } catch (IOException e) {
+        throw new MojoExecutionException("error while renaming EXML files", e);
+      }
+      return;
+    }
+
     // Convert main EXML sources to MXML:
     ExmlConfiguration config = createExmlConfiguration(getMavenPluginHelper().getActionScriptClassPath(false),
             Collections.singletonList(getSourceDirectory()), getSourceDirectory());
@@ -40,6 +65,16 @@ public class ExmlToMxmlMojo extends AbstractExmlMojo {
       ExmlConfiguration testConfig = createExmlConfiguration(getActionScriptTestClassPath(),
               Collections.singletonList(testSourceDirectory), testSourceDirectory);
       new Exmlc(testConfig).convertAllExmlToMxml();
+    }
+  }
+
+  private void renameFiles(File directory) throws IOException {
+    if (directory != null && directory.exists()) {
+      for (File exmlFile : listFiles(directory, new String[]{"exml"}, true)) {
+        File mxmlFile = new File(exmlFile.getParent(), getBaseName(exmlFile.getName()) + ".mxml");
+        getLog().debug(format("Renaming %s to %s", exmlFile.getPath(), mxmlFile.getPath()));
+        moveFile(exmlFile, mxmlFile);
+      }
     }
   }
 


### PR DESCRIPTION
... and to skip the actual conversion

This allows to give a hint to SCM systems like Git about the renaming and
then run the actual conversion in a second step.