### PR TITLE
Extended properties compiler to be able to handle cross resource bund…

### DIFF
--- a/exml/properties-compiler/src/main/java/net/jangaroo/properties/model/PropertiesClass.java
+++ b/exml/properties-compiler/src/main/java/net/jangaroo/properties/model/PropertiesClass.java
@@ -20,7 +20,7 @@ public class PropertiesClass {
 
   private static final Pattern AS3_IDENTIFIER_PATTERN = Pattern.compile("(\\p{Alpha}|[$_])(\\p{Alnum}|[$_])*");
   private static final Pattern RESOURCE_REFERENCE_PATTERN = Pattern.compile(
-          "^\\s*Resource\\s*\\(\\s*bundle\\s*=\\s*'([^']*)'\\s*,\\s*key\\s*=\\s*'([^']*)'\\s*\\)\\s*$"
+          "^\\s*Resource\\s*\\(\\s*key\\s*=\\s*'([^']*)'\\s*,\\s*bundle\\s*=\\s*'([^']*)'\\s*\\)\\s*$"
   );
 
   private ResourceBundleClass resourceBundle;
@@ -60,8 +60,8 @@ public class PropertiesClass {
       if (!matcher.find()) {
         props.add(new Property(adjustComment(layout.getCanonicalComment(key, true)), key, isIdentifier(key), value, true));
       } else {
-        String referenceBundleFullClassName = matcher.group(1);
-        String referenceBundleKey = matcher.group(2);
+        String referenceBundleKey = matcher.group(1);
+        String referenceBundleFullClassName = matcher.group(2);
 
         // extract class name without namespace
         String[] parts = referenceBundleFullClassName.split("\\.");
@@ -94,7 +94,7 @@ public class PropertiesClass {
       String value = properties.getString(key);
       Matcher matcher = RESOURCE_REFERENCE_PATTERN.matcher(value);
       if (matcher.find()) {
-        String referenceBundleFullClassName = matcher.group(1);
+        String referenceBundleFullClassName = matcher.group(2);
         result.add(referenceBundleFullClassName);
       }
     }

--- a/exml/properties-compiler/src/main/java/net/jangaroo/properties/model/PropertiesClass.java
+++ b/exml/properties-compiler/src/main/java/net/jangaroo/properties/model/PropertiesClass.java
@@ -57,19 +57,18 @@ public class PropertiesClass {
       String key = (String)keys.next();
       String value = properties.getString(key);
       Matcher matcher = RESOURCE_REFERENCE_PATTERN.matcher(value);
-      if (!matcher.find()) {
-        props.add(new Property(adjustComment(layout.getCanonicalComment(key, true)), key, isIdentifier(key), value, true));
-      } else {
+      boolean valueIsResourceReference = matcher.find();
+      if (valueIsResourceReference) {
         String referenceBundleKey = matcher.group(1);
         String referenceBundleFullClassName = matcher.group(2);
-
-        // extract class name without namespace
-        String[] parts = referenceBundleFullClassName.split("\\.");
-        String referenceBundleClassName = parts.length > 0 ? parts[parts.length - 1] : "";
-
-        value = referenceBundleClassName + ".INSTANCE[\"" + referenceBundleKey + "\"]";
-        props.add(new Property(adjustComment(layout.getCanonicalComment(key, true)), key, isIdentifier(key), value, false));
+        value = referenceBundleFullClassName + ".INSTANCE";
+        if (isIdentifier(referenceBundleKey)) {
+          value += "." + referenceBundleKey;
+        } else {
+          value += "[\"" + referenceBundleKey + "\"]";
+        }
       }
+      props.add(new Property(adjustComment(layout.getCanonicalComment(key, true)), key, isIdentifier(key), value, !valueIsResourceReference));
     }
     return props;
   }

--- a/exml/properties-compiler/src/main/java/net/jangaroo/properties/model/Property.java
+++ b/exml/properties-compiler/src/main/java/net/jangaroo/properties/model/Property.java
@@ -1,7 +1,5 @@
 package net.jangaroo.properties.model;
 
-import java.util.regex.Pattern;
-
 /**
  * A POJO to store key, value, and comment of a single property read from a properties file.
  */
@@ -11,12 +9,14 @@ public class Property {
   private String key;
   private boolean keyIsIdentifier;
   private String value;
+  private boolean valueIsString;
 
-  public Property(String comment, String key, boolean keyIsIdentifier, String value) {
+  public Property(String comment, String key, boolean keyIsIdentifier, String value, boolean valueIsString) {
     this.comment = comment;
     this.key = key;
     this.keyIsIdentifier = keyIsIdentifier;
     this.value = value;
+    this.valueIsString = valueIsString;
   }
 
   public String getComment() {
@@ -33,5 +33,9 @@ public class Property {
 
   public String getValue() {
     return value;
+  }
+
+  public boolean getValueIsString() {
+    return valueIsString;
   }
 }

--- a/exml/properties-compiler/src/main/resources/net/jangaroo/properties/templates/properties_class.ftl
+++ b/exml/properties-compiler/src/main/resources/net/jangaroo/properties/templates/properties_class.ftl
@@ -4,6 +4,9 @@ package ${resourceBundle.packageName} {
 import joo.ResourceBundleAwareClassLoader;
 import joo.JavaScriptObject;
 </#if>
+<#list imports as import>
+import ${import};
+</#list>
 
 <#if comment??>
 /**${comment}
@@ -35,7 +38,11 @@ public native function get ${property.key}():String;
 
 public function ${resourceBundle.className}_properties<#if locale??>_${locale}</#if>() {
 <#list props as property>
+<#if property.valueIsString>
   this["${property.key}"] = "${property.value?js_string}";
+<#else>
+  this["${property.key}"] = ${property.value};
+</#if>
 </#list>
 }
 }

--- a/exml/properties-compiler/src/test/java/PropertyClassGeneratorTest.java
+++ b/exml/properties-compiler/src/test/java/PropertyClassGeneratorTest.java
@@ -43,6 +43,7 @@ public class PropertyClassGeneratorTest {
     p.setProperty("key", "Die Platte \"{1}\" enthält {0}.");
     p.setProperty("key2", "Die Platte \"{1}\" enthält {0}.");
     p.setProperty("key3", "Resource(key='the_other_key'\\, bundle='testPackage.otherpackage.OtherProperties_properties')");
+    p.setProperty("key4", "Resource(key='the.other.key'\\, bundle='testPackage.otherpackage.OtherProperties_properties')");
     PropertiesClass pc = new PropertiesClass(rbc, null,p, null);
 
     generator.generatePropertiesClass(pc, writer);
@@ -66,11 +67,13 @@ public class PropertyClassGeneratorTest {
       "public native function get key():String;\n" +
       "public native function get key2():String;\n" +
       "public native function get key3():String;\n" +
+      "public native function get key4():String;\n" +
       "\n" +
       "public function PropertiesTest_properties() {\n" +
       "  this[\"key\"] = \"Die Platte \\\"{1}\\\" enthält {0}.\";\n" +
       "  this[\"key2\"] = \"Die Platte \\\"{1}\\\" enthält {0}.\";\n" +
-      "  this[\"key3\"] = OtherProperties_properties.INSTANCE[\"the_other_key\"];\n" +
+      "  this[\"key3\"] = testPackage.otherpackage.OtherProperties_properties.INSTANCE.the_other_key;\n" +
+      "  this[\"key4\"] = testPackage.otherpackage.OtherProperties_properties.INSTANCE[\"the.other.key\"];\n" +
       "}\n" +
       "}\n" +
       "}").replaceAll("\n", LINE_SEPARATOR), writer.toString());
@@ -92,7 +95,8 @@ public class PropertyClassGeneratorTest {
         "public function PropertiesTest_properties_en() {\n" +
         "  this[\"key\"] = \"Die Platte \\\"{1}\\\" enthält {0}.\";\n" +
         "  this[\"key2\"] = \"Die Platte \\\"{1}\\\" enthält {0}.\";\n" +
-        "  this[\"key3\"] = OtherProperties_properties.INSTANCE[\"the_other_key\"];\n" +
+        "  this[\"key3\"] = testPackage.otherpackage.OtherProperties_properties.INSTANCE.the_other_key;\n" +
+        "  this[\"key4\"] = testPackage.otherpackage.OtherProperties_properties.INSTANCE[\"the.other.key\"];\n" +
         "}\n" +
         "}\n" +
         "}").replaceAll("\n", LINE_SEPARATOR), writer.toString());

--- a/exml/properties-compiler/src/test/java/PropertyClassGeneratorTest.java
+++ b/exml/properties-compiler/src/test/java/PropertyClassGeneratorTest.java
@@ -42,7 +42,7 @@ public class PropertyClassGeneratorTest {
     PropertiesConfiguration p = new PropertiesConfiguration();
     p.setProperty("key", "Die Platte \"{1}\" enthält {0}.");
     p.setProperty("key2", "Die Platte \"{1}\" enthält {0}.");
-    p.setProperty("key3", "Resource(bundle='testPackage.otherpackage.OtherProperties_properties'\\, key='the_other_key')");
+    p.setProperty("key3", "Resource(key='the_other_key'\\, bundle='testPackage.otherpackage.OtherProperties_properties')");
     PropertiesClass pc = new PropertiesClass(rbc, null,p, null);
 
     generator.generatePropertiesClass(pc, writer);

--- a/exml/properties-compiler/src/test/java/PropertyClassGeneratorTest.java
+++ b/exml/properties-compiler/src/test/java/PropertyClassGeneratorTest.java
@@ -42,12 +42,14 @@ public class PropertyClassGeneratorTest {
     PropertiesConfiguration p = new PropertiesConfiguration();
     p.setProperty("key", "Die Platte \"{1}\" enthält {0}.");
     p.setProperty("key2", "Die Platte \"{1}\" enthält {0}.");
+    p.setProperty("key3", "Resource(bundle='testPackage.otherpackage.OtherProperties_properties'\\, key='the_other_key')");
     PropertiesClass pc = new PropertiesClass(rbc, null,p, null);
 
     generator.generatePropertiesClass(pc, writer);
     assertEquals(("package testPackage {\n" +
       "import joo.ResourceBundleAwareClassLoader;\n" +
       "import joo.JavaScriptObject;\n" +
+      "import testPackage.otherpackage.OtherProperties_properties;\n" +
       "\n" +
       "/**\n" +
       " * Properties class for ResourceBundle \"PropertiesTest\".\n" +
@@ -63,10 +65,12 @@ public class PropertyClassGeneratorTest {
       "\n" +
       "public native function get key():String;\n" +
       "public native function get key2():String;\n" +
+      "public native function get key3():String;\n" +
       "\n" +
       "public function PropertiesTest_properties() {\n" +
       "  this[\"key\"] = \"Die Platte \\\"{1}\\\" enthält {0}.\";\n" +
       "  this[\"key2\"] = \"Die Platte \\\"{1}\\\" enthält {0}.\";\n" +
+      "  this[\"key3\"] = OtherProperties_properties.INSTANCE[\"the_other_key\"];\n" +
       "}\n" +
       "}\n" +
       "}").replaceAll("\n", LINE_SEPARATOR), writer.toString());
@@ -76,6 +80,7 @@ public class PropertyClassGeneratorTest {
     writer  = new StringWriter();
     generator.generatePropertiesClass(psc, writer);
     assertEquals(("package testPackage {\n" +
+        "import testPackage.otherpackage.OtherProperties_properties;\n" +
         "\n" +
         "/**\n" +
         " * Properties class for ResourceBundle \"PropertiesTest\" and Locale \"en\".\n" +
@@ -87,6 +92,7 @@ public class PropertyClassGeneratorTest {
         "public function PropertiesTest_properties_en() {\n" +
         "  this[\"key\"] = \"Die Platte \\\"{1}\\\" enthält {0}.\";\n" +
         "  this[\"key2\"] = \"Die Platte \\\"{1}\\\" enthält {0}.\";\n" +
+        "  this[\"key3\"] = OtherProperties_properties.INSTANCE[\"the_other_key\"];\n" +
         "}\n" +
         "}\n" +
         "}").replaceAll("\n", LINE_SEPARATOR), writer.toString());


### PR DESCRIPTION
…le references

-e.g. by using Resource(bundle='com.coremedia.cms.editor.controlroom.icons.ControlRoomEditorIcons_properties', key='cut')
-inspired by @Resource directive of adobe flex
-very simple implementation using regex, only supporting white-spaces between tokens