### PR TITLE
Use no-fork goal for maven-source-plugin

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -37,7 +37,7 @@
             net.jangaroo:jangaroo-maven-plugin:${pom.version}:unpack-jangaroo-test-dependencies</test-compile>
           <test>net.jangaroo:jangaroo-maven-plugin:${pom.version}:test</test>
           <package>net.jangaroo:jangaroo-maven-plugin:${pom.version}:package</package>
-          <verify>org.apache.maven.plugins:maven-source-plugin:jar</verify>
+          <verify>org.apache.maven.plugins:maven-source-plugin:jar-no-fork</verify>
           <install>org.apache.maven.plugins:maven-install-plugin:install</install>
           <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
         </phases>


### PR DESCRIPTION
This avoids additional executions of some goals that have already be performed