### PR TITLE
graceful maven version handling

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/sencha/SenchaUtils.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/sencha/SenchaUtils.java
@@ -112,11 +112,16 @@ public class SenchaUtils {
 
   public static String getSenchaVersionForMavenVersion(String version) {
     // Very simple matching for now, maybe needs some adjustment
-    String senchaVersion = version.replaceAll("[^0-9.-]", "").replace("-", ".").replaceAll("[.]+", ".").replaceAll("[.]+$", "");
+    String senchaVersion = version
+      .replaceAll("[^0-9.-]", "")
+      .replace("-", ".")
+      .replaceAll("[.]+", ".")
+      .replaceAll("[.]+$", "")
+      .replaceAll("^[.]+", "");
     if (SENCHA_VERSION_PATTERN.matcher(senchaVersion).matches()) {
       return senchaVersion;
     } else {
-      return null;
+      return "0.0.1";
     }
   }
 


### PR DESCRIPTION
handling leading dots in case the maven version does start with some prefix live "bla-".
using "0.0.1" as a default version number in case the maven version does not contain any numbers.