### PR TITLE
make jangaroo-app packaging type fat

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -45,6 +45,7 @@
         <extension>jar</extension>
         <language>jangaroo</language>
         <addedToClasspath>false</addedToClasspath>
+        <includesDependencies>true</includesDependencies>
         <packaging>jangaroo-app</packaging>
       </configuration>
     </component>


### PR DESCRIPTION
set maven component attribut to make jangaroo-app packaging type fat without transitive dependencies

this is similar to the `war` packaging type, that also does not have transitive dependencies. If
transitive dependencies are required a dependency to the `pom` packaging type will restore the previous
behaviour.