### PR TITLE
[CMS-13355] Fixed remote repository scope for artifact lookup

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractSenchaMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractSenchaMojo.java
@@ -114,6 +114,7 @@ public abstract class AbstractSenchaMojo extends AbstractMojo {
     );
 
     ProjectBuildingRequest request = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+    request.setRemoteRepositories(project.getRemoteArtifactRepositories()); // The artifacts are available repositories defined in the projects - this also covers configured mirrors.
     request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
     request.setProcessPlugins(false);
     request.setResolveDependencies(false);


### PR DESCRIPTION
The default artifact lookup scope for project building requests contains
the remote repositories from the Maven session - which are actually the
remote repositories that are defined in the _settings.xml_. It doesn't
include remote repositories that are defined in the Maven project POMs
and are not cover by any configured mirror. To fix the lookup scope, the
remote repositories of the project building requests must be overwritten
with the projects remote artifact repositories - configured mirrors are
properly covered by them.