### PR TITLE
Added option --no-sandbox

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/test/JooTestMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/test/JooTestMojo.java
@@ -406,6 +406,7 @@ public class JooTestMojo extends AbstractSenchaMojo {
       case CHROME:
         ChromeOptions chromeOptions = new ChromeOptions();
         chromeOptions.setHeadless(true);
+        chromeOptions.addArguments("--no-sandbox");
         chromeOptions.addArguments("--disable-dev-shm-usage");
         return new ChromeDriver(chromeOptions);
       case FIREFOX:


### PR DESCRIPTION
It is likely that the option `--no-sandbox` is missing as well => See https://stackoverflow.com/questions/50642308/org-openqa-selenium-webdriverexception-unknown-error-devtoolsactiveport-file-d/50642913#50642913