### PR TITLE
Add Jetty fallback in case Jetty can't start a server on the provided port

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/RunMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/RunMojo.java
@@ -164,7 +164,12 @@ public class RunMojo extends AbstractSenchaMojo {
 
       jettyWrapper.blockUntilInterrupted();
     } catch (Exception e) {
-      throw new MojoExecutionException("Could not start Jetty", e);
+      getLog().info("Could not start Jetty. Try starting with a random port next");
+      try {
+        jettyWrapper.start(jooJettyHost, 0);
+      } catch (Exception ex) {
+        throw new MojoExecutionException("Could not start Jetty", e);
+      }
     } finally {
       jettyWrapper.stop();
     }

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/RunMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/RunMojo.java
@@ -164,18 +164,7 @@ public class RunMojo extends AbstractSenchaMojo {
 
       jettyWrapper.blockUntilInterrupted();
     } catch (Exception e) {
-      getLog().info("Could not start Jetty. Try starting with a random port next");
-      try {
-        jettyWrapper.start(jooJettyHost, 0);
-
-          getLog().info("Started Jetty server at: " + jettyWrapper.getUri());
-
-          logJangarooAppUrl(baseDir, jettyWrapper, project);
-
-          jettyWrapper.blockUntilInterrupted();
-      } catch (Exception ex) {
-        throw new MojoExecutionException("Could not start Jetty", e);
-      }
+      throw new MojoExecutionException("Could not start Jetty", e);
     } finally {
       jettyWrapper.stop();
     }

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/RunMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/RunMojo.java
@@ -167,6 +167,12 @@ public class RunMojo extends AbstractSenchaMojo {
       getLog().info("Could not start Jetty. Try starting with a random port next");
       try {
         jettyWrapper.start(jooJettyHost, 0);
+
+          getLog().info("Started Jetty server at: " + jettyWrapper.getUri());
+
+          logJangarooAppUrl(baseDir, jettyWrapper, project);
+
+          jettyWrapper.blockUntilInterrupted();
       } catch (Exception ex) {
         throw new MojoExecutionException("Could not start Jetty", e);
       }

--- a/jangaroo/jangaroo-app-runner/src/main/java/net/jangaroo/apprunner/util/JettyWrapper.java
+++ b/jangaroo/jangaroo-app-runner/src/main/java/net/jangaroo/apprunner/util/JettyWrapper.java
@@ -263,6 +263,10 @@ public class JettyWrapper {
       shuffledPorts.add(i);
     }
     Collections.shuffle(shuffledPorts);
+
+    if (!shuffledPorts.contains(0))
+      shuffledPorts.add(0);
+
     return shuffledPorts;
   }
 


### PR DESCRIPTION
if starting a jetty server on a provided port or range fails, we should automatically try to start a jetty server on a port chosen by jetty. this is done by adding '0' as last item of the shuffledPorts list.