### PR TITLE
Feature: Allow jangaroo-app-overlay without app dependency

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractSenchaMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractSenchaMojo.java
@@ -232,7 +232,8 @@ public abstract class AbstractSenchaMojo extends AbstractMojo {
         }
       }
     }
-    throw new MojoExecutionException("Module of type " + Type.JANGAROO_APP_OVERLAY_PACKAGING +" must have a dependency on a module of type " + Type.JANGAROO_APP_PACKAGING + " or " + Type.JANGAROO_APP_OVERLAY_PACKAGING + ".");
+    // no base app, that's okay, you just must tag dependencies as scope provided so that we know what to package:
+    return new JangarooAppOverlay(project, null);
   }
 
   JangarooApps createJangarooApps(MavenProject project) throws MojoExecutionException {
@@ -400,18 +401,23 @@ public abstract class AbstractSenchaMojo extends AbstractMojo {
 
     @Override
     JangarooApp getRootBaseApp() {
-      return baseApp.getRootBaseApp();
+      return baseApp == null ? null : baseApp.getRootBaseApp();
     }
 
     Set<Artifact> getOwnDynamicPackages() {
       LinkedHashSet<Artifact> ownDynamicPackages = new LinkedHashSet<>(packages);
-      ownDynamicPackages.removeAll(baseApp.packages);
+      if (baseApp != null) {
+        ownDynamicPackages.removeAll(baseApp.packages);
+      }
       return ownDynamicPackages;
     }
 
     Set<Artifact> getAllDynamicPackages() {
       LinkedHashSet<Artifact> allDynamicPackages = new LinkedHashSet<>(packages);
-      allDynamicPackages.removeAll(getRootBaseApp().packages);
+      JangarooApp rootBaseApp = getRootBaseApp();
+      if (rootBaseApp != null) {
+        allDynamicPackages.removeAll(rootBaseApp.packages);
+      }
       return allDynamicPackages;
     }
   }

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/RunMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/RunMojo.java
@@ -142,7 +142,9 @@ public class RunMojo extends AbstractSenchaMojo {
         JangarooApp jangarooApp = createJangarooApp(project);
         while (jangarooApp instanceof JangarooAppOverlay) {
           jangarooApp = ((JangarooAppOverlay) jangarooApp).baseApp;
-          addAppToResources(jettyWrapper, jangarooApp.mavenProject, ROOT_PATH, "");
+          if (jangarooApp != null) {
+            addAppToResources(jettyWrapper, jangarooApp.mavenProject, ROOT_PATH, "");
+          }
         }
 
         staticResourcesServletConfigs.add(new StaticResourcesServletConfig(JettyWrapper.ROOT_PATH_SPEC, SEPARATOR));


### PR DESCRIPTION
Until this change, a jangaroo-app-overlay had to provide a
dependency on a jangaroo-app(-overlay) artifact. This is
(only) used to determine the intersection of transitive
dependencies, so that the build process knows which
packages to bundle in the overlay artifact.
But there is another, maybe better way: In Maven, such
dependencies are meant to be declared
  <scope>provided</scope>
This makes the app dependency obsolete, which is preferable
for independently developed plugins.

Implementation: Just allow no jangaroo-app(-overlay)
dependency to be present. If so, construct a
JangarooAppOverlay with no (null) baseApp.
After checking for a null baseApp in several locations
and then simply skip the step that adds things from
the baseApp, the resulting packaging look like desired
(if all relevant dependencies are marked as provided).
The goal jangaroo:run works out of the box if you
specify jooProxyTargetSpec=/*