### PR TITLE
introduced new configuration npmPackageNameReplacers

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
@@ -272,7 +272,7 @@ public abstract class AbstractCompilerMojo extends AbstractJangarooMojo {
     configuration.setNpmPackageNameReplacers(
             npmPackageNameReplacers.stream()
                     .map(config -> new SearchAndReplace(Pattern.compile(config.getSearch()), config.getReplace()))
-            .collect(Collectors.toCollection(ArrayList::new))
+            .collect(Collectors.toList())
     );
 
     if (StringUtils.isNotEmpty(debuglevel)) {

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
@@ -8,6 +8,7 @@ import net.jangaroo.jooc.config.DebugMode;
 import net.jangaroo.jooc.config.JoocConfiguration;
 import net.jangaroo.jooc.config.NamespaceConfiguration;
 import net.jangaroo.jooc.config.PublicApiViolationsMode;
+import net.jangaroo.jooc.config.SearchAndReplace;
 import net.jangaroo.jooc.config.SemicolonInsertionMode;
 import net.jangaroo.jooc.mvnplugin.sencha.SenchaUtils;
 import net.jangaroo.jooc.mvnplugin.util.FileHelper;
@@ -27,6 +28,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Super class for mojos compiling Jangaroo sources.
@@ -158,6 +161,17 @@ public abstract class AbstractCompilerMojo extends AbstractJangarooMojo {
   @Parameter(property = "maven.compiler.suppressCommentedActionScriptCode")
   private boolean suppressCommentedActionScriptCode = false;
 
+  /**
+   * Experimental:
+   * Only effective if {@link #migrateToTypeScript} is enabled. The configuration can be used to replace the generated
+   * npm package name of a converted Maven module by a different one.
+   * It defines a list of replacers consisting of a search and a replace field. The search is interpreted as
+   * a regular pattern matched against the generated npm package name while the replacement is a string which can
+   * contain tokens (e.g. $1) matching pattern groups. Order is important, the first matching replacer wins.
+   */
+  @Parameter
+  private List<NpmPackageNameReplacerConfiguration> npmPackageNameReplacers = new ArrayList<>();
+
   protected abstract List<File> getCompileSourceRoots();
 
   protected abstract File getOutputDirectory();
@@ -255,6 +269,11 @@ public abstract class AbstractCompilerMojo extends AbstractJangarooMojo {
     configuration.setMigrateToTypeScript(migrateToTypeScript);
     configuration.setUseEcmaParameterInitializerSemantics(useEcmaParameterInitializerSemantics);
     configuration.setSuppressCommentedActionScriptCode(suppressCommentedActionScriptCode);
+    configuration.setNpmPackageNameReplacers(
+            npmPackageNameReplacers.stream()
+                    .map(config -> new SearchAndReplace(Pattern.compile(config.getSearch()), config.getReplace()))
+            .collect(Collectors.toCollection(ArrayList::new))
+    );
 
     if (StringUtils.isNotEmpty(debuglevel)) {
       try {

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/NpmPackageNameReplacerConfiguration.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/NpmPackageNameReplacerConfiguration.java
@@ -1,0 +1,20 @@
+package net.jangaroo.jooc.mvnplugin;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public class NpmPackageNameReplacerConfiguration {
+
+  @Parameter
+  private String search;
+
+  @Parameter
+  private String replace;
+
+  public String getSearch() {
+    return search;
+  }
+
+  public String getReplace() {
+    return replace;
+  }
+}

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/PropertiesMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/PropertiesMojo.java
@@ -84,8 +84,7 @@ public class PropertiesMojo extends AbstractJangarooMojo {
       sourceFiles.add(new File(resourceDirectory,srcFileRelativePath));
     }
 
-    // no typescript needed here, so resolver can be null
-    Propc generator = new Propc(null);
+    Propc generator = new Propc();
     try {
       List<File> sourcePath = Collections.singletonList(resourceDirectory.getCanonicalFile());
       generator.generateApi(sourceFiles, sourcePath, apiOutputDirectory);

--- a/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocConfiguration.java
+++ b/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocConfiguration.java
@@ -28,6 +28,7 @@ public class JoocConfiguration extends FileLocations implements JoocOptions, Par
 
   private File apiOutputDirectory;
   private boolean migrateToTypeScript = false;
+  private List<SearchAndReplace> npmPackageNameReplacers = new ArrayList<>();
   private boolean useEcmaParameterInitializerSemantics = false;
 
   private boolean mergeOutput = false;
@@ -109,6 +110,11 @@ public class JoocConfiguration extends FileLocations implements JoocOptions, Par
   }
 
   @Override
+  public List<SearchAndReplace> getNpmPackageNameReplacers() {
+    return npmPackageNameReplacers;
+  }
+
+  @Override
   public boolean isUseEcmaParameterInitializerSemantics() {
     return useEcmaParameterInitializerSemantics;
   }
@@ -121,6 +127,10 @@ public class JoocConfiguration extends FileLocations implements JoocOptions, Par
   @Option(name="-epi", aliases = "--ecma-parameter-initializers", usage ="Use ECMAScript parameter initializer semantics (experimental)")
   public void setUseEcmaParameterInitializerSemantics(boolean useEcmaParameterInitializerSemantics) {
     this.useEcmaParameterInitializerSemantics = useEcmaParameterInitializerSemantics;
+  }
+
+  public void setNpmPackageNameReplacers(List<SearchAndReplace> npmPackageNameReplacers) {
+    this.npmPackageNameReplacers = npmPackageNameReplacers;
   }
 
   @Override

--- a/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocOptions.java
+++ b/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocOptions.java
@@ -1,6 +1,7 @@
 package net.jangaroo.jooc.config;
 
 import java.io.File;
+import java.util.List;
 
 public interface JoocOptions {
 
@@ -17,6 +18,8 @@ public interface JoocOptions {
   boolean isUseEcmaParameterInitializerSemantics();
 
   boolean isMigrateToTypeScript();
+
+  List<SearchAndReplace> getNpmPackageNameReplacers();
 
   PublicApiViolationsMode getPublicApiViolationsMode();
 

--- a/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/SearchAndReplace.java
+++ b/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/SearchAndReplace.java
@@ -1,0 +1,14 @@
+package net.jangaroo.jooc.config;
+
+import java.util.regex.Pattern;
+
+public class SearchAndReplace {
+
+  public final Pattern search;
+  public final String replace;
+
+  public SearchAndReplace(Pattern search, String replace) {
+    this.search = search;
+    this.replace = replace;
+  }
+}

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/JangarooParser.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/JangarooParser.java
@@ -184,7 +184,7 @@ public class JangarooParser implements CompilationUnitResolver, CompilationUnitR
   }
 
   public Reader createPropertiesClassReader(InputSource in) throws IOException {
-    Propc propertyClassGenerator = new Propc(this);
+    Propc propertyClassGenerator = new Propc();
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     propertyClassGenerator.generateApi(
             CompilerUtils.qNameFromRelativePath(in.getRelativePath()),

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/Jooc.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/Jooc.java
@@ -179,7 +179,7 @@ public class Jooc extends JangarooParser implements net.jangaroo.jooc.api.Jooc {
       sourcePathInputSource = PathInputSource.fromFiles(getConfig().getSourcePath(), new String[]{""}, true);
       classPathInputSource = PathInputSource.fromFiles(getConfig().getClassPath(), new String[]{"", JOO_API_IN_SWC_DIRECTORY_PREFIX}, false);
 
-      propertyClassGenerator = new Propc(this);
+      propertyClassGenerator = new Propc(new TypeScriptModuleResolver(this, getConfig().getNpmPackageNameReplacers()));
     } catch (IOException e) {
       throw new CompilerError("IO Exception occurred", e);
     }

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/MergedOutputCompilationUnitSinkFactory.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/MergedOutputCompilationUnitSinkFactory.java
@@ -48,7 +48,7 @@ public class MergedOutputCompilationUnitSinkFactory extends AbstractCompilationU
 
               compilationUnit.visit(new TransitiveAstVisitor(new EmbeddedAssetResolver(compilationUnit, compilationUnitRegistry)));
               compilationUnit.visit(outputFile.getName().endsWith(Jooc.TS_SUFFIX)
-                      ? new TypeScriptCodeGenerator(new TypeScriptModuleResolver(compilationUnitModelResolver), out, compilationUnitModelResolver)
+                      ? new TypeScriptCodeGenerator(new TypeScriptModuleResolver(compilationUnitModelResolver, getOptions().getNpmPackageNameReplacers()), out, compilationUnitModelResolver)
                       : new JsCodeGenerator(out, compilationUnitModelResolver, new JsModuleResolver(compilationUnitModelResolver)));
             } finally {
               out.close();

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/SingleFileCompilationUnitSinkFactory.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/SingleFileCompilationUnitSinkFactory.java
@@ -82,7 +82,7 @@ public class SingleFileCompilationUnitSinkFactory extends AbstractCompilationUni
             try {
               out.setOptions(getOptions());
               compilationUnit.visit(new TransitiveAstVisitor(new EmbeddedAssetResolver(compilationUnit, compilationUnitRegistry)));
-              compilationUnit.visit(Jooc.OUTPUT_FILE_SUFFIX.equals(suffix) ? new JsCodeGenerator(out, compilationUnitModelResolver, new JsModuleResolver(compilationUnitModelResolver)) : new TypeScriptCodeGenerator(new TypeScriptModuleResolver(compilationUnitModelResolver), out, compilationUnitModelResolver));
+              compilationUnit.visit(Jooc.OUTPUT_FILE_SUFFIX.equals(suffix) ? new JsCodeGenerator(out, compilationUnitModelResolver, new JsModuleResolver(compilationUnitModelResolver)) : new TypeScriptCodeGenerator(new TypeScriptModuleResolver(compilationUnitModelResolver, getOptions().getNpmPackageNameReplacers()), out, compilationUnitModelResolver));
               if (options.isGenerateSourceMaps()) {
                 codeSuffix = generateSourceMap(out, outFile);
               }

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/properties/Propc.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/properties/Propc.java
@@ -8,7 +8,7 @@ import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import net.jangaroo.jooc.CompilationUnitResolver;
+import net.jangaroo.jooc.backend.TypeScriptModuleResolver;
 import net.jangaroo.properties.model.PropertiesClass;
 import net.jangaroo.properties.model.ResourceBundleClass;
 import net.jangaroo.utils.CompilerUtils;
@@ -45,10 +45,14 @@ public class Propc {
     cfg.setOutputEncoding("UTF-8");
   }
 
-  private final CompilationUnitResolver compilationUnitResolver;
+  private final TypeScriptModuleResolver typeScriptModuleResolver;
 
-  public Propc(CompilationUnitResolver compilationUnitResolver) {
-    this.compilationUnitResolver = compilationUnitResolver;
+  public Propc(TypeScriptModuleResolver typeScriptModuleResolver) {
+    this.typeScriptModuleResolver = typeScriptModuleResolver;
+  }
+
+  public Propc() {
+    this(null);
   }
 
   public void generateApi(String propertiesClassName, InputStream sourceInputStream, OutputStreamWriter writer) throws IOException {
@@ -127,7 +131,7 @@ public class Propc {
     }
     ResourceBundleClass bundle = new ResourceBundleClass(PropcHelper.computeBaseClassName(propertiesClassName));
 
-    return new PropertiesClass(bundle, PropcHelper.computeLocale(propertiesClassName), p, compilationUnitResolver);
+    return new PropertiesClass(bundle, PropcHelper.computeLocale(propertiesClassName), p, typeScriptModuleResolver);
   }
 
   /**

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/properties/model/PropertiesClass.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/properties/model/PropertiesClass.java
@@ -3,7 +3,6 @@
  */
 package net.jangaroo.properties.model;
 
-import net.jangaroo.jooc.CompilationUnitResolver;
 import net.jangaroo.jooc.backend.TypeScriptModuleResolver;
 import net.jangaroo.utils.CompilerUtils;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -33,13 +32,13 @@ public class PropertiesClass {
   private final ResourceBundleClass resourceBundle;
   private final Locale locale;
   private final PropertiesConfiguration properties;
-  private final CompilationUnitResolver compilationUnitResolver;
+  private final TypeScriptModuleResolver typeScriptModuleResolver;
 
-  public PropertiesClass(ResourceBundleClass resourceBundle, Locale locale, PropertiesConfiguration properties, CompilationUnitResolver compilationUnitResolver) {
+  public PropertiesClass(ResourceBundleClass resourceBundle, Locale locale, PropertiesConfiguration properties, TypeScriptModuleResolver typeScriptModuleResolver) {
     this.resourceBundle = resourceBundle;
     this.locale = locale;
     this.properties = properties;
-    this.compilationUnitResolver = compilationUnitResolver;
+    this.typeScriptModuleResolver = typeScriptModuleResolver;
   }
 
   public ResourceBundleClass getResourceBundle() {
@@ -147,7 +146,6 @@ public class PropertiesClass {
       // in TypeScript every module has to be imported, even if it is in the same folder/"package"
       imports.add(resourceBundle.getFullClassName());
     }
-    TypeScriptModuleResolver typeScriptModuleResolver = new TypeScriptModuleResolver(compilationUnitResolver);
     return typeScriptModuleResolver.getDefaultImports(resourceBundle.getFullClassName(), imports).stream()
             .collect(Collectors.toMap(im -> im.localName, im -> im.source));
   }


### PR DESCRIPTION
replacers are called when migrating to typescript and trying to retrieve the new npm package name of a given module. Every replacer needs a search and a replace configuration. The search is interpreted as a regular pattern while the replacement can contain tokens (e.g. $1) matching pattern groups.