### PR TITLE
Add TS integration tests (4.1)

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
@@ -396,7 +396,7 @@ public abstract class AbstractCompilerMojo extends AbstractJangarooMojo {
     String outputFileSuffix = Jooc.AS_SUFFIX;
     if (outputDirectory == null) {
       outputDirectory = getClassesOutputDirectory();
-      outputFileSuffix = isMigrateToTypeScript() ? Jooc.TS_SUFFIX : Jooc.OUTPUT_FILE_SUFFIX;
+      outputFileSuffix = Jooc.getOutputSuffix(isMigrateToTypeScript());
     }
     List<File> compileSourceRoots = getCompileSourceRoots();
     List<File> staleFiles = new ArrayList<>();

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/Jooc.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/Jooc.java
@@ -107,6 +107,10 @@ public class Jooc extends JangarooParser implements net.jangaroo.jooc.api.Jooc {
   public static final String TS_SUFFIX = ".ts";
   public static final String D_TS_SUFFIX = ".d" + TS_SUFFIX;
 
+  public static String getOutputSuffix(boolean isMigrateToTypeScript) {
+    return isMigrateToTypeScript ? TS_SUFFIX : OUTPUT_FILE_SUFFIX;
+  }
+
   private final List<FileInputSource> compileQueue = new ArrayList<>();
 
   public Jooc() {
@@ -129,6 +133,10 @@ public class Jooc extends JangarooParser implements net.jangaroo.jooc.api.Jooc {
   @Override
   public void setConfig(JoocConfiguration config) {
     super.setConfig(config);
+  }
+
+  public String getOutputSuffix() {
+    return getOutputSuffix(getConfig().isMigrateToTypeScript());
   }
 
   @Override
@@ -364,7 +372,7 @@ public class Jooc extends JangarooParser implements net.jangaroo.jooc.api.Jooc {
     CompilationUnitSinkFactory codeSinkFactory = null;
 
     if (suffix == null) {
-      suffix = config.isMigrateToTypeScript() ? TS_SUFFIX : OUTPUT_FILE_SUFFIX;
+      suffix = getOutputSuffix();
     }
     boolean generateTypeScriptIndexDTS = D_TS_SUFFIX.equals(suffix);
     boolean generateActionScriptApi = AS_SUFFIX.equals(suffix);

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/ast/FunctionExpr.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/ast/FunctionExpr.java
@@ -184,8 +184,10 @@ public class FunctionExpr extends Expr {
     }
     if (optBody != null) {
       TypeRelation typeRelation = getOptTypeRelation();
+      List<Directive> directives = optBody.getDirectives();
       if (typeRelation != null && AS3Type.VOID.name.equals(typeRelation.getType().getIde().getName()) &&
-              Ide.THIS.equals(getReturnTypeFromAnnotation())) {
+              Ide.THIS.equals(getReturnTypeFromAnnotation()) &&
+              !(!directives.isEmpty() && directives.get(directives.size() - 1) instanceof ReturnStatement)) {
         // complement a final "return this":
         ReturnStatement returnThis = new ReturnStatement(new JooSymbol(sym.RETURN, "return"),null,
                 new JooSymbol(sym.SEMICOLON, ";"));

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/ast/IdeExpr.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/ast/IdeExpr.java
@@ -80,7 +80,7 @@ public class IdeExpr extends Expr {
             setThisDeclaration(thisIde);
           }
           dotExpr = new DotExpr(new IdeExpr(thisIde), synthesizeDotSymbol(ideSymbol), new Ide(ideSymbol.withoutWhitespace()));
-        } else if (!ideDeclaration.isPrivate() || ((Jooc) ide.getScope().getCompiler()).getConfig().isMigrateToTypeScript()) {
+        } else if (!ideDeclaration.isPrivate() || ideDeclaration instanceof TypedIdeDeclaration && ((Jooc) ide.getScope().getCompiler()).getConfig().isMigrateToTypeScript()) {
           // non-private static class member: synthesize "<Class>."
           // TODO: ugly: This is the only code in package ast that queries whether we are in TypeScript mode!
           // If we fixed MyClass.privateAccessor JS code generation, we could always add the class, even for private statics.

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/ast/IdeExpr.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/ast/IdeExpr.java
@@ -16,7 +16,6 @@
 package net.jangaroo.jooc.ast;
 
 import net.jangaroo.jooc.JooSymbol;
-import net.jangaroo.jooc.Jooc;
 import net.jangaroo.jooc.Scope;
 import net.jangaroo.jooc.sym;
 import net.jangaroo.jooc.types.ExpressionType;
@@ -80,13 +79,11 @@ public class IdeExpr extends Expr {
             setThisDeclaration(thisIde);
           }
           dotExpr = new DotExpr(new IdeExpr(thisIde), synthesizeDotSymbol(ideSymbol), new Ide(ideSymbol.withoutWhitespace()));
-        } else if (!ideDeclaration.isPrivate() || ideDeclaration instanceof TypedIdeDeclaration && ((Jooc) ide.getScope().getCompiler()).getConfig().isMigrateToTypeScript()) {
-          // non-private static class member: synthesize "<Class>."
-          // TODO: ugly: This is the only code in package ast that queries whether we are in TypeScript mode!
-          // If we fixed MyClass.privateAccessor JS code generation, we could always add the class, even for private statics.
+        } else if (ideDeclaration instanceof TypedIdeDeclaration) {
+          // static class member: synthesize "<Class>."
           JooSymbol ideSymbol = ide.getSymbol();
           ClassDeclaration classDeclaration = ideDeclaration.getClassDeclaration();
-          Ide classIde = new Ide(ideSymbol.replacingSymAndTextAndJooValue(sym.IDE, classDeclaration.getName(), null));
+          Ide classIde = new Ide(ideSymbol.replacingSymAndTextAndJooValue(sym.IDE, classDeclaration.getName(), null).virtual());
           classIde.setDeclaration(classDeclaration); // must not be resolved again, as implicit imports through super class chain are not found in scope!
           dotExpr = new DotExpr(new IdeExpr(classIde), synthesizeDotSymbol(ideSymbol), new Ide(ideSymbol.withoutWhitespace()));
         }

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/ast/LiteralExpr.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/ast/LiteralExpr.java
@@ -31,7 +31,7 @@ public class LiteralExpr extends Expr {
   private Scope scope;
 
   public LiteralExpr(JooSymbol value) {
-    this.setValue(value);
+    this.value = value;
   }
 
   @Override
@@ -84,7 +84,14 @@ public class LiteralExpr extends Expr {
     return value;
   }
 
-  public void setValue(JooSymbol value) {
-    this.value = value;
+  public LiteralExpr withStringValue(String newValue) {
+    // keep the same quotes if possible:
+    String quote = value.getJooValue() instanceof String ? value.getText().substring(0, 1) : "\"";
+    LiteralExpr literalExpr = new LiteralExpr(new JooSymbol(value.sym, value.getFileName(),
+            value.getLine(), value.getColumn(), value.getWhitespace(),
+            quote + newValue + quote,
+            newValue));
+    literalExpr.scope(scope);
+    return literalExpr;
   }
 }

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/EmbeddedAssetResolver.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/EmbeddedAssetResolver.java
@@ -41,7 +41,7 @@ class EmbeddedAssetResolver extends AstVisitorBase {
   @Override
   public void visitAnnotationParameter(AnnotationParameter annotationParameter) throws IOException {
     AstNode value = annotationParameter.getValue();
-    if (value != null) {
+    if (value instanceof LiteralExpr) {
       Annotation parentAnnotation = annotationParameter.getParentAnnotation();
       String metaName = parentAnnotation.getMetaName();
       if (Jooc.EMBED_ANNOTATION_NAME.equals(metaName) && annotationParameter.getOptName() != null &&
@@ -51,8 +51,6 @@ class EmbeddedAssetResolver extends AstVisitorBase {
           throw new CompilerError(valueSymbol, "The source parameter of an [Embed] annotation must be a string literal");
         }
 
-        String text = valueSymbol.getText();
-        String quote = text.substring(0, 1);
         String source = (String) valueSymbol.getJooValue();
         String path = source.startsWith("/") || source.startsWith("\\")
                 ? source
@@ -65,11 +63,7 @@ class EmbeddedAssetResolver extends AstVisitorBase {
         if ("image".equals(assetType)) {
           unit.addDependency(compilationUnitRegistry.getCompilationUnit("flash.display.Bitmap"), false);
         }
-        String absoluteSource = path;
-        annotationParameter.setValue(new LiteralExpr(new JooSymbol(valueSymbol.sym, valueSymbol.getFileName(),
-                valueSymbol.getLine(), valueSymbol.getColumn(), valueSymbol.getWhitespace(),
-                quote + absoluteSource + quote,
-                absoluteSource)));
+        annotationParameter.setValue(((LiteralExpr) value).withStringValue(path));
       }
     }
   }

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptCodeGenerator.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptCodeGenerator.java
@@ -1216,7 +1216,7 @@ public class TypeScriptCodeGenerator extends CodeGeneratorBase {
     out.writeSymbolWhitespace(objectField.getSymbol());
     out.writeToken("...");
     String whitespace = exmlAppendOrPrepend.getSymbol().getWhitespace();
-    exmlAppendOrPrepend.getSymbol().setWhitespace("");
+    out.suppressWhitespace(exmlAppendOrPrepend.getSymbol());
     exmlAppendOrPrepend.visit(this);
     ParenthesizedExpr<CommaSeparatedList<Expr>> args = ((ApplyExpr) objectField.getValue()).getArgs();
     out.writeTokenForSymbol("({", args.getLParen());

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/properties/model/PropertiesClass.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/properties/model/PropertiesClass.java
@@ -92,7 +92,7 @@ public class PropertiesClass {
         String referenceBundleFullClassName = matcher.group(bundleFirst ? 2 : 4);
         int dotPos = referenceBundleFullClassName.lastIndexOf('.');
         String className = dotPos > -1 ? referenceBundleFullClassName.substring(dotPos + 1) : referenceBundleFullClassName;
-        value = referenceBundleFullClassName + CompilerUtils.PROPERTIES_CLASS_SUFFIX;
+        value = referenceBundleFullClassName + CompilerUtils.PROPERTIES_CLASS_SUFFIX + ".INSTANCE";
         tsValue = className + CompilerUtils.PROPERTIES_CLASS_SUFFIX;
         if (isIdentifier(referenceBundleKey)) {
           value += "." + referenceBundleKey;

--- a/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/AbstractJoocTest.java
+++ b/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/AbstractJoocTest.java
@@ -150,13 +150,13 @@ public class AbstractJoocTest {
   void assertNoCompilationFailures(String relativeClassFileName) throws URISyntaxException, IOException {
     compile(".as", relativeClassFileName);
 
-    File destFile = outputFile(outputFolder, relativeClassFileName, ".js");
+    File destFile = outputFile(outputFolder, relativeClassFileName, jooc.getOutputSuffix());
     assertFalse("Compile errors: test marked as failure.", jooc.getLog().hasErrors());
     assertTrue("the output file " + destFile + " should exist, but doesn't", destFile.exists());
   }
 
   void verifyClassOutput(String relativeClassFileName, String expectedPath) throws URISyntaxException, IOException {
-    verifyOutput(relativeClassFileName, outputFolder, expectedPath, ".js");
+    verifyOutput(relativeClassFileName, outputFolder, expectedPath, jooc.getOutputSuffix());
   }
 
   void verifyApiOutput(String relativeClassFileName, String expectedPath) throws URISyntaxException, IOException {

--- a/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/AbstractJoocTest.java
+++ b/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/AbstractJoocTest.java
@@ -142,6 +142,16 @@ public class AbstractJoocTest {
   }
 
   void assertCompilationResult(String relativeClassFileName, String extension, String expectedPath) throws URISyntaxException, IOException {
+    internalAssertCompilationResult(relativeClassFileName, extension, expectedPath);
+    config.setMigrateToTypeScript(true);
+    try {
+      internalAssertCompilationResult(relativeClassFileName, extension, expectedPath);
+    } finally {
+      config.setMigrateToTypeScript(false);
+    }
+  }
+
+  private void internalAssertCompilationResult(String relativeClassFileName, String extension, String expectedPath) throws URISyntaxException, IOException {
     compile(extension, relativeClassFileName);
     assertFalse("Compile errors: test marked as failure.", jooc.getLog().hasErrors());
     verifyClassOutput(relativeClassFileName, expectedPath);

--- a/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/JoocMxmlTest.java
+++ b/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/JoocMxmlTest.java
@@ -42,6 +42,7 @@ public class JoocMxmlTest extends AbstractJoocTest {
 
   @Test
   public void testTestComponent() throws Exception {
+    assertCompilationResult("package1/mxml/pkg/TestComponentBase", ".as");
     assertCompilationResult("package1/mxml/pkg/TestComponent", ".mxml");
   }
 

--- a/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/JoocPropertiesTest.java
+++ b/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/JoocPropertiesTest.java
@@ -10,6 +10,16 @@ public class JoocPropertiesTest extends AbstractJoocTest {
 
   @Test
   public void testPropertiesCompilation() throws Exception {
+    verifyPropertiesCompilation();
+    jooc.getConfig().setMigrateToTypeScript(true);
+    try {
+      verifyPropertiesCompilation();
+    } finally {
+      jooc.getConfig().setMigrateToTypeScript(false);
+    }
+  }
+
+  private void verifyPropertiesCompilation() throws Exception {
     compile(".properties",
             "testPackage/PropertiesTest",
             "testPackage/PropertiesTest_de",

--- a/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/JoocPropertiesTest.java
+++ b/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/JoocPropertiesTest.java
@@ -25,7 +25,11 @@ public class JoocPropertiesTest extends AbstractJoocTest {
   }
 
   void verifyPropertiesOutput(String relativeClassFileName, String locale) throws URISyntaxException, IOException {
-    verifyOutput(relativeClassFileName, propertiesTargetDir(locale), "/expectedProperties/" + locale, ".js");
+    if (jooc.getConfig().isMigrateToTypeScript()) {
+      verifyClassOutput(relativeClassFileName + ("en".equals(locale) ? "" : "_" + locale), "/expected");
+    } else {
+      verifyOutput(relativeClassFileName, propertiesTargetDir(locale), "/expectedProperties/" + locale, ".js");
+    }
   }
 
   private File propertiesTargetDir(String locale) throws URISyntaxException {

--- a/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/JoocTest.java
+++ b/jangaroo/jangaroo-compiler/src/test/java/net/jangaroo/jooc/JoocTest.java
@@ -160,7 +160,7 @@ public class JoocTest extends AbstractJoocTest {
   public void testMixin() throws Exception {
     final String relativeClassFileName = "package2/ITestMixin";
     compile(relativeClassFileName);
-    File compileResult = outputFile(outputFolder, relativeClassFileName, ".js");
+    File compileResult = outputFile(outputFolder, relativeClassFileName, jooc.getOutputSuffix());
 
     assertFalse("[Mixin] interfaces must not have compile output.", compileResult.exists());
     assertCompilationResult("package2/TestMixinClient");

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AllElements.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AllElements.ts
@@ -1,0 +1,141 @@
+import {_, cast} from '@jangaroo/joo/AS3';
+import button from '../ext/config/button';
+import menuitem from '../ext/config/menuitem';
+import allElements from '../exmlparser/config/allElements';
+import someMixin from '../ext/config/someMixin';
+import aplugin from '../ext/config/aplugin';
+import uint from '../AS3/int_';
+import int from '../AS3/int_';
+import panel from '../ext/config/panel';
+import Exml from '../net/jangaroo/ext/Exml';
+import MessageBox from '../ext/MessageBox';
+
+class AllElementsConfigs {
+
+      /*
+      anonymous object in array:
+
+      tools:[
+        {id:"gear",
+        handler:function(){} }
+      ]
+       */
+      
+       gear:any = null;}
+interface AllElements_ extends Partial<AllElementsConfigs> {
+}
+
+
+/**
+ This is my <b>TestComponent</b>
+ */
+class AllElements<Cfg extends AllElements._ = AllElements._> extends panel<Cfg>{
+
+    /**
+     * This is my <b>constant</b>
+     */
+     static readonly SOME_CONSTANT:uint = allElements.SOME_CONSTANT;
+    /**
+     * This is another <b>constant</b>
+     */
+     static readonly ANOTHER_CONSTANT:string = allElements.ANOTHER_CONSTANT;
+     static readonly CODE_CONSTANT:int = allElements.CODE_CONSTANT;
+
+     #myProperty:string = null;
+     #myVar:string = null;
+     #myVar2:any = null;
+     #myVar3:button = null;
+     #myVar4:Array<any> = null;
+
+    //@ts-expect-error 18022
+     #__initialize__(config:AllElements._):void {
+      this.#myVar = config.#myProperty + '_suffix';
+      this.#myVar2 = {
+        prop: config.#myProperty
+      };
+    }
+
+     constructor(config:AllElements._ = null){
+    super((()=>{this.#__initialize__(config);
+  
+    this.#myVar3 = new button(_<button._>({
+            text: "Foo"}));
+  
+    this.#myVar4 =[
+      { header: "a", sortable: false, menuDisabled: true},
+      { header: "b", sortable: true, menuDisabled: false}
+    ];
+    return  Exml.apply(new AllElements._({
+           title: "I am a panel",
+           layout: Exml.asString( config.#myProperty),
+
+    /* define some attributes through a typed mixin: */
+    mixins:[
+      cast(someMixin,{
+        ...Exml.append({someList: [
+          cast(button,{ text: "click me!", id: "myId",
+            baseAction:
+              new ext.Action(_<Action._>({
+            }))
+          })
+        ]})
+      })
+    ],
+
+    /* attribute*/
+    layoutConfig:
+      { bla: "blub", anchor: "test", border: "solid"
+    },
+
+    /* array with component
+    items:{xtype:"testAll", ...}
+     */
+    items:[
+      cast(button,{ text: "Save",
+        handler: ():void => {
+          MessageBox.alert('gotcha!');
+        }
+      }),
+      {xtype: "editortreepanel"},
+      {}
+    ],
+
+
+    /* array
+    menu:[
+      {...},
+      {...}
+    ]
+     */
+    menu:[
+      cast(menuitem,{ text: "juhu1"}),
+      cast(menuitem,{ text: "juhu2"}),
+      cast(menuitem,{ text: "juhu3"})
+    ],
+
+    tools:[
+      /*
+      anonymous object in array:
+
+      tools:[
+        {id:"gear",
+        handler:function(){} }
+      ]
+       */
+      this.setConfig("gear" ,{ handler: (x) => ''+x})
+    ],
+
+    plugins:[
+      cast(aplugin,{}),
+      cast(aplugin,{})
+    ]
+
+}),config);})());
+  }}
+declare namespace AllElements {
+  export type _ = AllElements_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default AllElements;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AuxVarConfusion.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AuxVarConfusion.ts
@@ -1,0 +1,12 @@
+
+
+ class AuxVarConfusion {
+
+   doSomething():void {
+    for (var i of Object.values({foo:true} || {})) {
+      new AuxVarConfusion();
+    }
+  }
+
+}
+export default AuxVarConfusion;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/CannotResolveMember.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/CannotResolveMember.ts
@@ -1,0 +1,38 @@
+import ConfigClass from './ConfigClass';
+
+ class CannotResolveMember {
+    #ccList:Array<ConfigClass> = [];
+
+   constructor() {
+    var configClass = new ConfigClass();
+    configClass['wrong7'];
+    configClass['wrong8']();
+    configClass.getConfig("title")['wrong9'];
+
+    new ConfigClass()['wrong11'];
+    this.#getConfigClass()['wrong12'];
+    this.#getConfigClass().getConfig("title")['wrong13'];
+    this.#getConfigClass().toString()['wrong14'];
+
+    this.#ccList[0]['wrong16'];
+    this.#ccList[0].getConfig("title")['wrong17'];
+    this.#getCCList()[0].getConfig("title")['wrong18'];
+    this.#getCCList()[0].getConfig("title")['wrong19'];
+
+    var vector:Array<Array<string>> =[["a", "b"]];
+    vector[0][0]['wrong22'];
+  }
+
+  
+  //@ts-expect-error 18022
+   #getCCList():Array<ConfigClass> {
+    return this.#ccList;
+  }
+
+  //@ts-expect-error 18022
+   #getConfigClass():ConfigClass {
+    return new ConfigClass();
+  }
+
+}
+export default CannotResolveMember;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ChainedConstants.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ChainedConstants.ts
@@ -1,0 +1,16 @@
+import SomeOtherClass from './someOtherPackage/SomeOtherClass';
+import int from '../AS3/int_';
+
+
+ class ChainedConstants {
+   static readonly METHOD_TYPE_GET : string = "get";
+
+   static readonly DEFAULT_METHOD_TYPE : string = ChainedConstants.METHOD_TYPE_GET;
+
+   static readonly THE_METHOD_TYPE : string = ChainedConstants.METHOD_TYPE_GET;
+
+   static readonly ANOTHER_METHOD_TYPE : string = ChainedConstants.METHOD_TYPE_GET.substr(0, 1);
+
+   static readonly THE_BLA : int = SomeOtherClass.BLA;
+}
+export default ChainedConstants;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ConfigClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ConfigClass.ts
@@ -1,0 +1,53 @@
+import Observable from '../ext/mixin/Observable';
+import int from '../AS3/int_';
+
+class ConfigClassProperties {
+
+   foo:string = "foo";
+
+   number:int = 0;/*
+
+  @DefaultProperty*/
+  
+
+    items:Array<any>;
+
+  
+
+    defaults:any;}
+
+class ConfigClassConfigs {
+
+  
+
+  
+   title:string;}
+interface ConfigClass_ extends Partial<ConfigClassProperties>, Partial<ConfigClassConfigs> {
+}
+
+
+
+
+
+ class ConfigClass<Cfg extends ConfigClass._ = ConfigClass._> extends Observable<Cfg> {
+
+   constructor(config:ConfigClass._ = null) {
+    super();
+  }
+
+   #_title:string = "- empty -";getTitle():string {
+    return this.#_title;
+  }
+   setTitle(value:string) {
+    this.#_title = value;
+  }
+}
+interface ConfigClass<Cfg extends ConfigClass._ = ConfigClass._>extends ConfigClassProperties{}
+
+declare namespace ConfigClass {
+  export type _ = ConfigClass_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default ConfigClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/FieldInitializer.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/FieldInitializer.ts
@@ -1,0 +1,11 @@
+
+ class FieldInitializer {
+  readonly #const1:string = "foo";
+  readonly #const2:any = "foo" + "bar";
+  readonly #const3:Record<string,any> = {"foo": "bar"};
+
+   foo():string {
+    return this.#const1 + this.#const2 + this.#const3;
+  }
+}
+export default FieldInitializer;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ImplementsInterface.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ImplementsInterface.ts
@@ -1,0 +1,42 @@
+import {mixin} from '@jangaroo/joo/AS3';
+import Interface from './Interface';
+import Panel from '../ext/Panel';
+
+
+  class ImplementsInterface implements Interface {
+
+  /**
+   * Field with ASDoc.
+   * Second line.
+   */
+   foo;/*
+  
+  /**
+   * Annotated field with ASDoc.
+   * /
+  @Bar*/
+   bar:Array<Array<Panel>> = null;
+
+   constructor() {
+    // nothing really
+  }
+
+   doSomething():string {
+    this.bar = new Array();
+    var panels = new Array();
+    panels.push(new Panel({}));
+    this.bar.push(panels);
+    this.bar[0][0].setConfig("title" , "Gotcha!");
+  }
+
+   get property():string {
+    return "prefix" + this.foo;
+  }
+
+   set property(value:string) {
+    this.foo = value.substr("prefix".length);
+  }
+}
+mixin(ImplementsInterface, Interface);
+
+export default ImplementsInterface;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/IncludedClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/IncludedClass.ts
@@ -1,0 +1,9 @@
+import {metadata} from '@jangaroo/joo/AS3';
+/*
+@AnotherAnnotation*/
+
+ class IncludedClass {
+}
+metadata(IncludedClass, ["AnotherAnnotation"]);
+
+export default IncludedClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/Interface.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/Interface.ts
@@ -1,0 +1,13 @@
+import SuperInterface from './SuperInterface';
+
+
+/**
+ * Some ASDoc.
+ */
+// this comment should vanish in the API!
+ abstract class Interface extends SuperInterface {
+  abstract doSomething():string;
+
+  abstract property:string;
+}
+export default Interface;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/NoCodeExpression.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/NoCodeExpression.ts
@@ -1,0 +1,8 @@
+import {metadata} from '@jangaroo/joo/AS3';
+/*
+@RemoteClass({"_""{this is not a code expression}", alias:"{this is also not a code expression}"})*/
+ class NoCodeExpression {
+}
+metadata(NoCodeExpression, ["RemoteClass", {"": "{this is not a code expression}", alias: "{this is also not a code expression}"}]);
+
+export default NoCodeExpression;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/NoMultipleThisAliases.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/NoMultipleThisAliases.ts
@@ -1,0 +1,15 @@
+
+ class NoMultipleThisAliases {
+   constructor() {const this$=this;
+    function foo1():void {
+      this$.#method();
+    }
+    function foo2():void {
+      this$.#method();
+    }
+  }
+
+  //@ts-expect-error 18022
+   #method():void {}
+}
+export default NoMultipleThisAliases;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/NoPrimitiveInit.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/NoPrimitiveInit.ts
@@ -1,0 +1,14 @@
+import SomeOtherClass from './someOtherPackage/SomeOtherClass';
+import int from '../AS3/int_';
+
+
+ class NoPrimitiveInit {
+   constructor() {
+  }
+
+  //@ts-expect-error 18022
+   #method(i:int):int {
+    return SomeOtherClass.BLA + int.MAX_VALUE;
+  }
+}
+export default NoPrimitiveInit;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ParameterInitializers.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ParameterInitializers.ts
@@ -1,0 +1,10 @@
+import NaN from '../NaN';
+import undefined from '../undefined';
+
+
+ class ParameterInitializers {
+   constructor(str = "foo", integer = 1, num2 = NaN,
+                                        bool = false, obj = null, undef?) {
+  }
+}
+export default ParameterInitializers;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/PrivateMemberAccess.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/PrivateMemberAccess.ts
@@ -1,0 +1,11 @@
+
+ class PrivateMemberAccess {
+
+   static readonly INSTANCE:PrivateMemberAccess = new PrivateMemberAccess();
+   #secret:string = null;
+
+   static doSomething():string {
+    return PrivateMemberAccess.INSTANCE.#secret;
+  }
+}
+export default PrivateMemberAccess;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/StaticAndNonStatic.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/StaticAndNonStatic.ts
@@ -1,0 +1,15 @@
+
+
+/**
+ * Retest for JOO-64.
+ */
+ class StaticAndNonStatic {
+
+   StaticAndNonStatic:string = null;
+  
+  // noinspection JSUnusedLocalSymbols
+  private static static$yxTL = (() => {
+    new StaticAndNonStatic();
+  })();
+}
+export default StaticAndNonStatic;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/SuperCallParameters.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/SuperCallParameters.ts
@@ -1,0 +1,13 @@
+import ManyConstructorParameters from './ManyConstructorParameters';
+
+
+ class SuperCallParameters extends ManyConstructorParameters {
+   constructor() {
+    super("bar", -1, -4.2, true, {}, []);
+  }
+
+    isEmpty(str:string):boolean {
+    return super.isEmpty(str);
+  }
+}
+export default SuperCallParameters;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestArrayForIn.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestArrayForIn.ts
@@ -1,0 +1,57 @@
+import int from '../AS3/int_';
+
+
+   const ARRAY:Array<any> = [1, 2, 3];
+
+ class TestArrayForIn {
+  //@ts-expect-error 18022
+   static #array:Array<any> = [1, 2, 3];
+
+   static test():Array<any> {
+    var a = [1, 2, 3];
+    // test rewrite of Array for ... in with local variable
+    for (var i1 in a) {
+      TestArrayForIn.#doSomething(a[i1]);
+    }
+    // test rewrite of Array for each ... in with Array literal
+    for (var e0 of [1, 2, 3] as int[]) {
+      TestArrayForIn.#doSomething(e0);
+    }
+    // test rewrite of Array for each ... in with local variable
+    for (var e1 of a as int[]) {
+      TestArrayForIn.#doSomething(e1);
+    }
+    // test rewrite of Array for each ... in with field
+    for (var e2a of TestArrayForIn.#array as int[]) {
+      TestArrayForIn.#doSomething(e2a);
+    }
+    // test rewrite of Array for each ... in with field using explicit class
+    for (var e2b of TestArrayForIn.#array as int[]) {
+      TestArrayForIn.#doSomething(e2b);
+    }
+    // test rewrite of Array for each ... in with static const
+    for (var e3 of ARRAY as int[]) {
+      TestArrayForIn.#doSomething(e3);
+    }
+    var e4:int;
+    // test rewrite of Array for each ... in with pre-declared loop variable
+    for (e4 of a) {
+      TestArrayForIn.#doSomething(e4);
+    }
+    // test rewrite of Array for ... in where the first argument is an lvalue
+    var indexes = [];
+    for (indexes[indexes.length] in a) {}
+    TestArrayForIn.#doSomething(indexes);
+
+    // test rewrite of Array for each ... in where the first argument is an lvalue
+    var copy = [];
+    for (copy[copy.length] of a) {}
+    return copy;
+  }
+
+  //@ts-expect-error 18022
+   static #doSomething(param:any):void {
+    // do something...
+  }
+}
+export default TestArrayForIn;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestBind.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestBind.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2008 CoreMedia AG
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, 
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+ * express or implied. See the License for the specific language 
+ * governing permissions and limitations under the License.
+ */
+
+import {bind} from '@jangaroo/joo/AS3';
+
+
+ class TestBind {
+
+   boundField:AnyFunction =bind( this,this.#getStatePrivate);
+
+   constructor(state : string) {
+    this.#state = state;
+    var bound:AnyFunction =bind( this,this.#getStatePrivate);
+  }
+
+  
+  //@ts-expect-error 18022
+   #testCoerce(shouldBeString: any):void {}
+
+   getState() : string {
+    this.boundField.call( null);
+    this.#testCoerce(String(1));
+    this.#testCoerce("1");
+    return this.#state;
+  }
+
+  
+   chainable():this {
+    if (this.getState()) {
+      this.#testCoerce("nothing here");
+      return this;
+    }
+    this.#testCoerce("nothing there");return this;
+  }
+
+  //@ts-expect-error 18022
+   #getStatePrivate() : string {
+    return this.#state;
+  }
+
+   #state : string = null;
+
+}
+export default TestBind;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestHelperClasses.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestHelperClasses.ts
@@ -1,0 +1,38 @@
+import {bind} from '@jangaroo/joo/AS3';
+
+
+ class TestHelperClasses {
+
+   static readonly TEXT:string = "foo";
+   static getText():string {
+    var thc = new Helper("foo");
+    var f:AnyFunction =bind( thc,thc.getText);
+    return f();
+  }
+
+   static getConstantFromHelperClass():string {
+    return Helper.CONST;
+  }
+}
+
+class Helper {
+
+   static readonly CONST:string = "FOO";
+   #text:string = TestHelperClasses.TEXT;
+
+   constructor(text:string) {
+    this.#text = text;
+  }
+
+   getText():string {
+    var f:AnyFunction =bind( this,this.#text_getter);
+    f =bind( this,this.#text_getter);
+    return f();
+  }
+
+  //@ts-expect-error 18022
+   #text_getter():string {
+    return this.#text;
+  }
+}
+export default TestHelperClasses;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestIdeWithReservedName.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestIdeWithReservedName.ts
@@ -1,0 +1,14 @@
+
+ class TestIdeWithReservedName {
+   parameterWithReservedName(char:string):string {
+    char = char + "!";
+    return char;
+  }
+
+   localVarWithReservedName():string {
+    var char = "x";
+    char = char.substr(0,0) + "u";
+    return char;
+  }
+}
+export default TestIdeWithReservedName;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestMethodCall.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestMethodCall.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2008 CoreMedia AG
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, 
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+ * express or implied. See the License for the specific language 
+ * governing permissions and limitations under the License.
+ */
+
+import int from '../AS3/int_';
+
+
+/**
+* a comment
+*/
+ class TestMethodCall /* blub ber *//*extends Object*/ {
+
+   constructor() {
+  } s:TestMethodCall = null;
+
+  static  s(x :int) :int {
+    return x;
+  }
+
+   m(x :int) :int {
+    return x;
+  }
+
+  protected prot(x :int) :int {
+    return x+1;
+  }
+
+  //@ts-expect-error 18022
+   #priv(x :int) :int {
+    return x+2;
+  }
+
+   callm(x :int, t:TestMethodCall) :int {
+    return t.m(x);
+  }
+
+   callmViaThis(x :int, t:TestMethodCall) :int {
+    return this.m(x);
+  }
+
+   callmViaObject(x :int, t:TestMethodCall) :int {
+    var o:Record<string,any> = { t: t };
+    return o.t.m(x);
+  }
+
+   callmViaVar(x :int, t:TestMethodCall) :int {
+    var o = t;
+    return o.m(x);
+  }
+
+   callmViaField(x :int, t:TestMethodCall) :int {
+    this.s = t;
+    return this.s.m(x);
+  }
+
+   callmViaThisDotField(x :int, t:TestMethodCall) :int {
+    this.s = t;
+    return this.s.m(x);
+  }
+
+   callProt(x :int, t:TestMethodCall) :int {
+    return t.prot(x);
+  }
+
+   callProtViaThis(x :int, t:TestMethodCall) :int {
+    return this.prot(x);
+  }
+
+   callProtViaObject(x :int, t:TestMethodCall) :int {
+    var o:Record<string,any> = { t: t };
+    return o.t.prot(x);
+  }
+
+   callProtViaVar(x :int, t:TestMethodCall) :int {
+    var o = t;
+    return o.prot(x);
+  }
+
+   callProtViaField(x :int, t:TestMethodCall) :int {
+    this.s = t;
+    return this.s.prot(x);
+  }
+
+   callProtViaThisDotField(x :int, t:TestMethodCall) :int {
+    this.s = t;
+    return this.s.prot(x);
+  }
+
+   callPriv(x :int, t:TestMethodCall) :int {
+    return t.#priv(x);
+  }
+
+   callPrivViaThis(x :int, t:TestMethodCall) :int {
+    return this.#priv(x);
+  }
+
+   callPrivViaObject(x :int, t:TestMethodCall) :int {
+    var o:Record<string,any> = { t: t };
+    return o.t.priv(x);
+  }
+
+   callPrivViaVar(x :int, t:TestMethodCall) :int {
+    var o = t;
+    return o.#priv(x);
+  }
+
+   callPrivViaField(x :int, t:TestMethodCall) :int {
+    this.s = t;
+    return this.s.#priv(x);
+  }
+
+   callPrivViaThisDotField(x :int, t:TestMethodCall) :int {
+    this.s = t;
+    return this.s.#priv(x);
+  }
+
+
+}
+export default TestMethodCall;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestResolveMembers.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestResolveMembers.ts
@@ -1,0 +1,11 @@
+import Interface from './Interface';
+
+ class TestResolveMembers {
+
+   constructor() {
+    // resolve Object methods on something typed by an interface:
+    var someInterface:Interface;
+    var str = someInterface.toString();
+  }
+}
+export default TestResolveMembers;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestStaticNonStaticConfusion.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestStaticNonStaticConfusion.ts
@@ -1,0 +1,19 @@
+
+ class TestStaticNonStaticConfusion {
+
+   constructor() {
+    this.#foo();
+    this.#foo();
+    TestStaticNonStaticConfusion.foo();
+  }
+
+   static foo():string {
+    return "static foo";
+  }
+
+  //@ts-expect-error 18022
+   #foo():string {
+    return "foo";
+  }
+}
+export default TestStaticNonStaticConfusion;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestTypeCast.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestTypeCast.ts
@@ -1,0 +1,30 @@
+import {as, cast, is} from '@jangaroo/joo/AS3';
+import Number from '../Number';
+import uint from '../AS3/int_';
+import int from '../AS3/int_';
+
+
+ class TestTypeCast {
+
+   constructor() {
+  }
+
+   static testAsCast(p : any) : TestTypeCast {
+    var r = 99.7;
+    var n = Number("99.8");
+    var i = int(r);
+    var b =is( p,  TestTypeCast);
+    var notB :boolean = !is(p,  TestTypeCast);
+    return as( p,  TestTypeCast);
+  }
+
+   static testCastToUint(any:any):uint {
+    return uint(any);
+  }
+
+   static testCastToClassVar(clazz:Class, value:any):any {
+    return cast(clazz,value);
+  }
+
+}
+export default TestTypeCast;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestUndeclaredIdeError.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/TestUndeclaredIdeError.ts
@@ -1,0 +1,11 @@
+
+
+ class TestUndeclaredIdeError {
+  
+   constructor() {
+    undeclaredIde6 = 5;
+    var x:any = undeclaredIde7;
+    undeclaredIde8;
+  }
+}
+export default TestUndeclaredIdeError;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/UsingEmbed.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/UsingEmbed.ts
@@ -1,0 +1,56 @@
+import {metadata} from '@jangaroo/joo/AS3';
+import Bitmap from '../flash/display/Bitmap';
+/*
+
+@SomeRuntimeAnnotation
+/**
+ * This is an example of a class using an [Embed] annotation.
+ * /
+@SomeRuntimeAnnotation({foo:"bar"})*/
+ class UsingEmbed {
+
+  
+   someText:Class = null;
+
+  
+  //@ts-expect-error 18022
+   static #anotherText:Class = null;
+
+  
+  //@ts-expect-error 18022
+   static #jooley:Class = null;/*
+
+  @SomeRuntimeAnnotation*/
+   annotated1;/*
+
+  @SomeRuntimeAnnotationWithArg({"_""foo"})*/
+   annotated2() {
+  }/*
+
+  @SomeRuntimeAnnotationWithNamedArg({foo:"bar"})*/
+   annotated3() {
+  }/*
+
+  @SomeRuntimeAnnotationWithNamedArg({foo:"bar"})*/
+   annotated4() {
+  }/*
+
+  /**
+   * multiple
+   * /
+  @SomeRuntimeAnnotation({type:"bar"})
+  /**
+   * annotations
+   * /
+  @SomeRuntimeAnnotation({type:"baz"})*/
+   annotated5() {
+  }/*
+
+  @SomePropertyAnnotation({"_"1})*/
+    annotated6:string;
+
+}
+metadata(UsingEmbed, ["SomeRuntimeAnnotation"],
+    "SomeRuntimeAnnotation", {foo: "bar"}]);
+
+export default UsingEmbed;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/UsingSomeNativeClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/UsingSomeNativeClass.ts
@@ -1,0 +1,44 @@
+import package1_someOtherPackage_SomeNativeClass from './someOtherPackage/SomeNativeClass';
+import SomeOtherNativeClass from '../SomeOtherNativeClass';
+
+
+/**
+ * This is an example of a class using a "native" class.
+ */
+ class UsingSomeNativeClass {
+
+   someNative:SomeNativeClass = new SomeNativeClass();
+   someOtherNative:SomeOtherNativeClass = new SomeOtherNativeClass();
+   readonly someNative2:SomeNativeClass;
+
+   constructor() {const this$=this;
+    new package1_someOtherPackage_SomeNativeClass();
+    this.someNative.setConfig("baz" , "foo");
+    this.someNative2.setConfig("baz" , "foo");
+    var local = ():void => {
+      var test = this.someNative2.getConfig("baz");
+    };
+    var foo = this.getConfig("someNativeAccessor");
+    var bar = this.getConfig("anotherNativeAccessor");
+  }
+
+  
+   getSomeNativeAccessor():SomeNativeClass {
+    return this.someNative;
+  }
+
+  
+   getAnotherNativeAccessor():SomeNativeClass {
+    return this.someNative;
+  }
+
+  
+   getMonkey():boolean {
+    return false;
+  }
+
+  
+   setMonkey(value:boolean) {
+  }
+}
+export default UsingSomeNativeClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/UsingSomePackageGlobal.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/UsingSomePackageGlobal.ts
@@ -1,0 +1,18 @@
+import somePackageGlobal from './somePackageGlobal';
+import SomeOtherClass from './someOtherPackage/SomeOtherClass';
+
+
+/**
+ * This is an example of a class using a "package global" variable.
+ */
+ class UsingSomePackageGlobal {
+
+   static main():void {
+    somePackageGlobal._ = new SomeOtherClass();
+    var local:any = somePackageGlobal._ || {};
+    foo.somethingElse = null;
+    var local2:any = foo.somethingElse || {};
+  }
+
+}
+export default UsingSomePackageGlobal;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/WithStaticReference.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/WithStaticReference.ts
@@ -1,0 +1,22 @@
+import {is} from '@jangaroo/joo/AS3';
+
+ class WithStaticReference {
+   static readonly BLA = "bla";
+   constructor() {
+    var bla = WithStaticReference.BLA;is(
+    bla,  WithStaticReference);
+    this.#make2();
+  }
+   static make():void {
+    var bla = WithStaticReference.BLA;is(
+    bla,  WithStaticReference);
+    new WithStaticReference();
+  }
+  //@ts-expect-error 18022
+   #make2():void {
+    var bla = WithStaticReference.BLA;is(
+    bla,  WithStaticReference);
+    new WithStaticReference();
+  }
+}
+export default WithStaticReference;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/AInstantiatesB.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/AInstantiatesB.ts
@@ -1,0 +1,25 @@
+import {_, cast} from '@jangaroo/joo/AS3';
+import Exml from '../../net/jangaroo/ext/Exml';
+import Panel from '../../ext/Panel';
+import BDeclaresA from './BDeclaresA';
+interface AInstantiatesB_ {
+}
+
+
+class AInstantiatesB<Cfg extends AInstantiatesB._ = AInstantiatesB._> extends Panel<Cfg>{
+
+     constructor(config:AInstantiatesB._ = null){
+    super( Exml.apply(new AInstantiatesB._({
+
+  items:[
+    new BDeclaresA(_<BDeclaresA._>({ someProperty: "yes"}))
+  ]
+}),config));
+  }}
+declare namespace AInstantiatesB {
+  export type _ = AInstantiatesB_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default AInstantiatesB;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/DeclarationsMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/DeclarationsMxmlClass.ts
@@ -1,0 +1,63 @@
+import {_} from '@jangaroo/joo/AS3';
+import SomeNativeClass from '../someOtherPackage/SomeNativeClass';
+import Exml from '../../net/jangaroo/ext/Exml';
+import ConfigClass from '../ConfigClass';
+import SomeOtherClass from '../someOtherPackage/SomeOtherClass';
+import int from '../../AS3/int_';
+
+class DeclarationsMxmlClassConfigs {
+
+    
+     bar:string = null;
+
+    /**
+     Some number.
+     */
+    
+     num:int = 0;
+
+    /**
+     Empty declaration.
+     */
+    
+     empty:int = 0;
+
+    
+     blub:any = null;
+
+    
+     list:Array<any> = null;
+
+    
+     other:SomeOtherClass = null;}
+interface DeclarationsMxmlClass_ extends Partial<DeclarationsMxmlClassConfigs> {
+}
+
+
+class DeclarationsMxmlClass<Cfg extends DeclarationsMxmlClass._ = DeclarationsMxmlClass._> extends SomeNativeClass<Cfg>{constructor(config:DeclarationsMxmlClass._=null){
+    super();
+    this.setConfig("bar" , "BAR!");
+    /**
+     Some number.
+     */
+    this.setConfig("num" , 123);
+    this.setConfig("blub" ,{ name: "Kuno"});
+    this.setConfig("list" ,[
+      { name: "Joe"},
+      new ConfigClass(_<ConfigClass._>({
+        items:[
+          new SomeOtherClass(_<SomeOtherClass._>({ bla: 123}))
+        ]
+      }))
+    ]);
+    this.setConfig("other" , new SomeOtherClass(_<SomeOtherClass._>({ bla: 3,
+                        blubb_config: 'blub config expression',
+                        blubb_accessor: 'blub accessor expression'}))); Exml.apply(this,config);
+}}
+declare namespace DeclarationsMxmlClass {
+  export type _ = DeclarationsMxmlClass_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default DeclarationsMxmlClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/InterfaceImplementingMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/InterfaceImplementingMxmlClass.ts
@@ -1,0 +1,37 @@
+import {cast, mixin} from '@jangaroo/joo/AS3';
+import SimpleInterface from './SimpleInterface';
+import Exml from '../../net/jangaroo/ext/Exml';
+import ConfigClass from '../ConfigClass';
+import SimpleClass from './SimpleClass';
+import YetAnotherInterface from './YetAnotherInterface';
+
+class InterfaceImplementingMxmlClassConfigs {
+
+    
+
+    /** @private */
+    
+      someProperty:string;}
+interface InterfaceImplementingMxmlClass_ extends ConfigClass._, Partial<InterfaceImplementingMxmlClassConfigs> {
+}
+
+
+class InterfaceImplementingMxmlClass<Cfg extends InterfaceImplementingMxmlClass._ = InterfaceImplementingMxmlClass._> extends ConfigClass<Cfg> implements YetAnotherInterface{
+
+     constructor(config:InterfaceImplementingMxmlClass._ = null){
+    super( Exml.apply(new InterfaceImplementingMxmlClass._({
+}),config));
+  }}
+interface InterfaceImplementingMxmlClass<Cfg extends InterfaceImplementingMxmlClass._ = InterfaceImplementingMxmlClass._>{
+
+      createInstance(o:SimpleInterface):SimpleClass;}
+
+mixin(InterfaceImplementingMxmlClass, YetAnotherInterface);
+
+declare namespace InterfaceImplementingMxmlClass {
+  export type _ = InterfaceImplementingMxmlClass_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default InterfaceImplementingMxmlClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataCdataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataCdataMxmlClass.ts
@@ -1,0 +1,28 @@
+import {cast, metadata} from '@jangaroo/joo/AS3';
+import Exml from '../../net/jangaroo/ext/Exml';
+import ConfigClass from '../ConfigClass';
+interface MetadataCdataMxmlClass_ extends ConfigClass._ {
+}
+
+/*
+
+    /**
+     * Let's have a class with two annotations.
+     * @see {@link http://help.adobe.com/en_US/flex/using/WSd0ded3821e0d52fe1e63e3d11c2f44bc36-7ff2.html}
+     * /
+    @ThisIsJustATest
+    @Deprecated ({replacement:'use.this.please'})*/
+class MetadataCdataMxmlClass<Cfg extends MetadataCdataMxmlClass._ = MetadataCdataMxmlClass._> extends ConfigClass<Cfg>{constructor(config:MetadataCdataMxmlClass._=null){
+    super( Exml.apply(new MetadataCdataMxmlClass._({
+}),config));
+}}
+metadata(MetadataCdataMxmlClass, ["ThisIsJustATest"],
+    "Deprecated", {replacement: 'use.this.please'}]);
+
+declare namespace MetadataCdataMxmlClass {
+  export type _ = MetadataCdataMxmlClass_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default MetadataCdataMxmlClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataMxmlClass.ts
@@ -1,0 +1,24 @@
+import {cast, metadata} from '@jangaroo/joo/AS3';
+import Exml from '../../net/jangaroo/ext/Exml';
+import ConfigClass from '../ConfigClass';
+interface MetadataMxmlClass_ extends ConfigClass._ {
+}
+
+/*
+
+    @ThisIsJustATest
+    @Deprecated ({replacement:'use.this.please'})*/
+class MetadataMxmlClass<Cfg extends MetadataMxmlClass._ = MetadataMxmlClass._> extends ConfigClass<Cfg>{constructor(config:MetadataMxmlClass._=null){
+    super( Exml.apply(new MetadataMxmlClass._({
+}),config));
+}}
+metadata(MetadataMxmlClass, ["ThisIsJustATest"],
+    "Deprecated", {replacement: 'use.this.please'}]);
+
+declare namespace MetadataMxmlClass {
+  export type _ = MetadataMxmlClass_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default MetadataMxmlClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/ScriptCdataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/ScriptCdataMxmlClass.ts
@@ -1,0 +1,38 @@
+import {cast, mixin} from '@jangaroo/joo/AS3';
+import SimpleInterface from './SimpleInterface';
+import Exml from '../../net/jangaroo/ext/Exml';
+import ConfigClass from '../ConfigClass';
+import SomeOtherClass from '../someOtherPackage/SomeOtherClass';
+import int from '../../AS3/int_';
+
+class ScriptCdataMxmlClassProperties {
+     field3:Array<int> =[1, 2, 3];}
+interface ScriptCdataMxmlClass_ extends ConfigClass._, Partial<ScriptCdataMxmlClassProperties> {
+}
+
+
+class ScriptCdataMxmlClass<Cfg extends ScriptCdataMxmlClass._ = ScriptCdataMxmlClass._> extends ConfigClass<Cfg> implements SimpleInterface{
+
+     #field1:SomeOtherClass = null;
+    protected field2:Array<string> =["a", "b"];
+
+     doIt(...values):void {
+      for (var v in values) {
+        throw "cannot do it with " + v;
+      }
+    }constructor(config:ScriptCdataMxmlClass._=null){
+    super( Exml.apply(new ScriptCdataMxmlClass._({
+             foo: "bar"
+}),config));
+}}
+interface ScriptCdataMxmlClass<Cfg extends ScriptCdataMxmlClass._ = ScriptCdataMxmlClass._>extends ScriptCdataMxmlClassProperties{}
+
+mixin(ScriptCdataMxmlClass, SimpleInterface);
+
+declare namespace ScriptCdataMxmlClass {
+  export type _ = ScriptCdataMxmlClass_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default ScriptCdataMxmlClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMetadataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMetadataMxmlClass.ts
@@ -1,0 +1,21 @@
+import {cast, metadata} from '@jangaroo/joo/AS3';
+import Exml from '../../net/jangaroo/ext/Exml';
+import ConfigClass from '../ConfigClass';
+interface SimpleMetadataMxmlClass_ extends ConfigClass._ {
+}
+
+/*
+@ShortVersion*/
+class SimpleMetadataMxmlClass<Cfg extends SimpleMetadataMxmlClass._ = SimpleMetadataMxmlClass._> extends ConfigClass<Cfg>{constructor(config:SimpleMetadataMxmlClass._=null){
+    super( Exml.apply(new SimpleMetadataMxmlClass._({
+}),config));
+}}
+metadata(SimpleMetadataMxmlClass, ["ShortVersion"]);
+
+declare namespace SimpleMetadataMxmlClass {
+  export type _ = SimpleMetadataMxmlClass_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default SimpleMetadataMxmlClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMxmlClass.ts
@@ -1,0 +1,150 @@
+import {_, bind, cast} from '@jangaroo/joo/AS3';
+import SomeEvent from '../someOtherPackage/SomeEvent';
+import Exml from '../../net/jangaroo/ext/Exml';
+import ConfigClass from '../ConfigClass';
+import SomeOtherClass from '../someOtherPackage/SomeOtherClass';
+import int from '../../AS3/int_';
+
+class SimpleMxmlClassConfigs {
+
+    
+     list:any = null;
+
+    
+     bar:string = null;
+
+    
+     computed:string = null;
+
+    /**
+     Some number.
+     */
+    
+     num:int = 0;
+
+    
+     empty:int = 0;
+
+    
+     someFlag1:boolean = false;
+
+    
+     anotherFlag1:boolean = false;
+
+    
+     someFlag2:boolean = false;
+
+    
+     anotherFlag2:boolean = false;
+
+    
+     someFlag3:boolean = false;
+
+    
+     anotherFlag3:boolean = false;
+
+    
+     emptyObject:any = null;
+
+    
+     joe:any = null;
+
+    
+     otherByExpression:any = null;
+
+    
+     other:SomeOtherClass = null;
+
+        
+         no_config:SomeOtherClass = null;}
+interface SimpleMxmlClass_ extends ConfigClass._, Partial<SimpleMxmlClassConfigs> {
+}
+
+
+/**
+  My config class subclass, authored in MXML.
+ */
+
+class SimpleMxmlClass<Cfg extends SimpleMxmlClass._ = SimpleMxmlClass._> extends ConfigClass<Cfg>{
+
+     static readonly xtype:string = "testNamespace.config.simpleMxmlClass";
+
+     constructor(config:SimpleMxmlClass._ = null){
+    super((()=>{
+    this.#blub ={ name: "Kuno"};
+    config = Exml.apply({
+    bar: "FOO & BAR!",
+    computed: Exml.asString( 'B' + 'AR!'),
+    /**
+     Some number.
+     */
+    num: 123,
+    someFlag2: false,
+    anotherFlag2: true,
+    someFlag3: false,
+    anotherFlag3: true,
+    joe: { name: "Joe"},
+    list: [
+      { name: "Joe"},
+      new ConfigClass(_<ConfigClass._>({items:[
+        new SomeOtherClass(_<SomeOtherClass._>({ bla: 123}))
+      ]}))
+    ],
+    otherByExpression: { foo: 'bar'},
+    other: new SomeOtherClass(_<SomeOtherClass._>({ bla: 3,
+                          blubb_config: 'blub config expression',
+                          blubb_accessor: 'blub accessor expression'}))
+    },config);
+    return  Exml.apply(new SimpleMxmlClass._({
+             foo: "bar",
+             number: 1 < 2  ? 1 + 1 : 3,
+  defaultType:
+    SomeOtherClass.xtype,
+  defaults:_<SomeOtherClass._&{"known-unknown"}>({ bla: 99,
+                          "known-unknown": true
+  }),
+  ...Exml.append({items: [
+    new SomeOtherClass(_<SomeOtherClass._>({ bla: 23})),
+    new SomeOtherClass(_<SomeOtherClass._>({ bla: 1,
+    listeners:{ clickClack: Exml.eventHandler( SomeEvent.CLICK_CLACK,SomeEvent,bind(this,this.#$on_clickClack_55_41))}})),
+    new SomeOtherClass(_<SomeOtherClass._&ConfigClass._>({ bla: 42, number: 24
+    })),
+    new ConfigClass(_<ConfigClass._>({
+      items:[
+        new SomeOtherClass(_<SomeOtherClass._>({ doodle: "non-bound", bla: this.getConfig("other").getConfig("bla")}))
+      ],
+      number: 12
+    })),
+    new ConfigClass(_<ConfigClass._>({
+      ...Exml.prepend({items: [
+        new SomeOtherClass(_<SomeOtherClass._>({ bla: 12})),
+        this.setConfig("no_config" , new SomeOtherClass(_<SomeOtherClass._>({ bla: 13})))
+      ]})
+    }))
+  ]}),
+    listeners:{
+             click: Exml.eventHandler( SomeEvent.CLICK,SomeEvent,bind(this,this.#$on_click_14_20))}
+}),config);})());
+  }
+
+     #blub:any;
+
+    // noinspection JSUnusedLocalSymbols
+  private static static$5_bR = (() =>{
+      if(1 < 0 && 0 > 1) {
+        throw "plain wrong!";
+      }
+    })();
+//@ts-expect-error 18022
+ #$on_click_14_20 (event:SomeEvent) :void {
+    var result = 'gotcha!';}
+//@ts-expect-error 18022
+ #$on_clickClack_55_41 (event:SomeEvent) :void {
+    var test=0;}}
+declare namespace SimpleMxmlClass {
+  export type _ = SimpleMxmlClass_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default SimpleMxmlClass;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/StringToArrayCoercion.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/StringToArrayCoercion.ts
@@ -1,0 +1,19 @@
+import {cast} from '@jangaroo/joo/AS3';
+import Exml from '../../net/jangaroo/ext/Exml';
+import Panel from '../../ext/Panel';
+interface StringToArrayCoercion_ {
+}
+
+
+class StringToArrayCoercion<Cfg extends StringToArrayCoercion._ = StringToArrayCoercion._> extends Panel<Cfg>{constructor(config:StringToArrayCoercion._=null){
+    super( Exml.apply(new StringToArrayCoercion._({
+           items: ["just a joke"]
+}),config));
+}}
+declare namespace StringToArrayCoercion {
+  export type _ = StringToArrayCoercion_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default StringToArrayCoercion;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/StringToEmptyArrayCoercion.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/StringToEmptyArrayCoercion.ts
@@ -1,0 +1,19 @@
+import {cast} from '@jangaroo/joo/AS3';
+import Exml from '../../net/jangaroo/ext/Exml';
+import Panel from '../../ext/Panel';
+interface StringToEmptyArrayCoercion_ {
+}
+
+
+class StringToEmptyArrayCoercion<Cfg extends StringToEmptyArrayCoercion._ = StringToEmptyArrayCoercion._> extends Panel<Cfg>{constructor(config:StringToEmptyArrayCoercion._=null){
+    super( Exml.apply(new StringToEmptyArrayCoercion._({
+  items:[]
+}),config));
+}}
+declare namespace StringToEmptyArrayCoercion {
+  export type _ = StringToEmptyArrayCoercion_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default StringToEmptyArrayCoercion;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/TestOldPropertyAccessSyntax.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/TestOldPropertyAccessSyntax.ts
@@ -1,0 +1,24 @@
+import Exml from '../../net/jangaroo/ext/Exml';
+import PropertiesTest_properties from '../../testPackage/PropertiesTest_properties';
+
+class TestOldPropertyAccessSyntaxConfigs {
+
+    
+     foo:string = null;}
+interface TestOldPropertyAccessSyntax_ extends Partial<TestOldPropertyAccessSyntaxConfigs> {
+}
+
+
+class TestOldPropertyAccessSyntax<Cfg extends TestOldPropertyAccessSyntax._ = TestOldPropertyAccessSyntax._> extends Object<Cfg>{
+
+     static readonly BUNDLE:PropertiesTest_properties = PropertiesTest_properties;constructor(config:TestOldPropertyAccessSyntax._=null){
+    super();
+    this.setConfig("foo" , Exml.asString( TestOldPropertyAccessSyntax.BUNDLE.key + "\"")); Exml.apply(this,config);
+}}
+declare namespace TestOldPropertyAccessSyntax {
+  export type _ = TestOldPropertyAccessSyntax_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default TestOldPropertyAccessSyntax;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/UndefinedTypeInBinding.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/UndefinedTypeInBinding.ts
@@ -1,0 +1,19 @@
+import {cast} from '@jangaroo/joo/AS3';
+import Exml from '../../net/jangaroo/ext/Exml';
+import TestComponentBase2 from './pkg2/TestComponentBase2';
+interface UndefinedTypeInBinding_ extends TestComponentBase2._ {
+}
+
+
+class UndefinedTypeInBinding<Cfg extends UndefinedTypeInBinding._ = UndefinedTypeInBinding._> extends TestComponentBase2<Cfg>{constructor(config:UndefinedTypeInBinding._=null){
+    super( Exml.apply(new UndefinedTypeInBinding._({
+        property_1: /* UndefinedType will raise compiler error */():any => UndefinedType(null)
+}),config));
+}}
+declare namespace UndefinedTypeInBinding {
+  export type _ = UndefinedTypeInBinding_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default UndefinedTypeInBinding;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/WhitespaceAroundBindingExpression.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/WhitespaceAroundBindingExpression.ts
@@ -1,0 +1,20 @@
+import {cast} from '@jangaroo/joo/AS3';
+import Exml from '../../net/jangaroo/ext/Exml';
+import Panel from '../../ext/Panel';
+import ContainerLayout from '../../ext/layout/ContainerLayout';
+interface WhitespaceAroundBindingExpression_ {
+}
+
+
+class WhitespaceAroundBindingExpression<Cfg extends WhitespaceAroundBindingExpression._ = WhitespaceAroundBindingExpression._> extends Panel<Cfg>{constructor(config:WhitespaceAroundBindingExpression._=null){
+    super( Exml.apply(new WhitespaceAroundBindingExpression._({
+  layout: new ContainerLayout()
+}),config));
+}}
+declare namespace WhitespaceAroundBindingExpression {
+  export type _ = WhitespaceAroundBindingExpression_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default WhitespaceAroundBindingExpression;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/CyclicDependencies.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/CyclicDependencies.ts
@@ -1,0 +1,23 @@
+import Exml from '../../../net/jangaroo/ext/Exml';
+import CyclicDependencies_1 from './CyclicDependencies_1';
+
+class CyclicDependenciesConfigs {
+
+    
+     cause_trouble:CyclicDependencies_1 = null;}
+interface CyclicDependencies_ extends Partial<CyclicDependenciesConfigs> {
+}
+
+
+class CyclicDependencies<Cfg extends CyclicDependencies._ = CyclicDependencies._> extends Object<Cfg>{
+
+     constructor(config:CyclicDependencies._ = null){
+    super(); Exml.apply(this,config);
+  }}
+declare namespace CyclicDependencies {
+  export type _ = CyclicDependencies_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default CyclicDependencies;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/PropertiesAccess.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/PropertiesAccess.ts
@@ -1,0 +1,21 @@
+import {cast} from '@jangaroo/joo/AS3';
+import Exml from '../../../net/jangaroo/ext/Exml';
+import PropertiesAccessBase from './PropertiesAccessBase';
+interface PropertiesAccess_ extends PropertiesAccessBase._ {
+}
+
+
+class PropertiesAccess<Cfg extends PropertiesAccess._ = PropertiesAccess._> extends PropertiesAccessBase<Cfg>{constructor(config:PropertiesAccess._=null){
+    super( Exml.apply(new PropertiesAccess._({
+        property_1: "egal",
+        property_2: "egaler",
+        property_3: "am egalsten"
+}),config));
+}}
+declare namespace PropertiesAccess {
+  export type _ = PropertiesAccess_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default PropertiesAccess;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/PropertiesAccessBase.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/PropertiesAccessBase.ts
@@ -1,0 +1,38 @@
+import PropertiesAccess from './PropertiesAccess';
+
+class PropertiesAccessBaseProperties {
+
+   property_1:string = null;
+
+   property_2:string;
+
+    property_3:string;}
+interface PropertiesAccessBase_ extends Partial<PropertiesAccessBaseProperties> {
+}
+
+
+
+ class PropertiesAccessBase<Cfg extends PropertiesAccess._ = PropertiesAccess._> {
+
+   constructor(config:PropertiesAccess._ = null) {
+    this.property_1 = config.property_1 += "_HI";
+    this.property_2 = 123;
+    this.property_3 = config.property_3 || "";
+  }
+   #_property_2:string = null;
+
+   set property_2(value:any) {
+    this.#_property_2 = String(value);
+  } get property_2():string {
+    return this.#_property_2;
+  }
+}
+interface PropertiesAccessBase<Cfg extends PropertiesAccess._ = PropertiesAccess._>extends PropertiesAccessBaseProperties{}
+
+declare namespace PropertiesAccessBase {
+  export type _ = PropertiesAccessBase_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default PropertiesAccessBase;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponent.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponent.ts
@@ -1,0 +1,40 @@
+import {cast} from '@jangaroo/joo/AS3';
+import Exml from '../../../net/jangaroo/ext/Exml';
+import TestComponentBase from './TestComponentBase';
+import int from '../../../AS3/int_';
+
+class TestComponentConfigs {
+
+    
+     property_1:string = null;
+
+
+    
+     property_2:int = 0;}
+interface TestComponent_ extends TestComponentBase._, Partial<TestComponentConfigs> {
+}
+
+
+class TestComponent<Cfg extends TestComponent._ = TestComponent._> extends TestComponentBase<Cfg>{
+
+     constructor(config:TestComponent._ = null){
+    config = Exml.apply({
+    property_1: "withDefault"
+    },config);
+    super( Exml.apply(new TestComponent._({
+        emptyText: Exml.asString( '<div class=\'widget-content-list-empty\'>' + TestComponentBase.DEFAULT + '</div>'),
+        letters: [
+              'a',
+              'b',
+              'c'
+             ]
+
+}),config));
+  }}
+declare namespace TestComponent {
+  export type _ = TestComponent_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default TestComponent;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponentBase.js
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponentBase.js
@@ -1,0 +1,47 @@
+/*package package1.mxml.pkg {*/
+
+
+Ext.define("package1.mxml.pkg.TestComponentBase", function(TestComponentBase) {/*public class TestComponentBase implements TestInterface {
+
+  public static const DEFAULT:String = "_DEFAULT_";
+
+  [ExtConfig]
+  [Bindable]
+  /**
+   * @private
+   * /
+  public native function set store(value:*):void;
+
+  public var emptyText:String;
+  public var letters:Array;
+
+  private var property_1:String;
+  private var property_2:int;
+
+  public*/ function TestComponentBase$(config/*:TestComponent = null*/) {if(arguments.length<=0)config=null;
+    this.property_1$00xv = AS3.setBindable(config,"property_1" , "_HI");
+    this.property_2$00xv = config.property_2 || 0;
+  }/*
+
+  private var component:Object;
+
+  public*/ function init(component/*:Object*/)/*:void*/ {
+    this.component$00xv = component;
+  }/*
+}
+}
+
+============================================== Jangaroo part ==============================================*/
+    return {
+      mixins: ["package1.mxml.pkg.TestInterface"],
+      emptyText: null,
+      letters: null,
+      property_1$00xv: null,
+      property_2$00xv: 0,
+      constructor: TestComponentBase$,
+      component$00xv: null,
+      init: init,
+      statics: {DEFAULT: "_DEFAULT_"},
+      requires: ["package1.mxml.pkg.TestInterface"]
+    };
+});

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponentBase.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponentBase.ts
@@ -1,0 +1,46 @@
+import {mixin} from '@jangaroo/joo/AS3';
+import TestComponent from './TestComponent';
+import TestInterface from './TestInterface';
+import int from '../../../AS3/int_';
+
+class TestComponentBaseProperties {
+
+   emptyText:string = null;
+   letters:Array<any> = null;}
+
+class TestComponentBaseConfigs {}
+interface TestComponentBase_ extends Partial<TestComponentBaseProperties>, Partial<TestComponentBaseConfigs> {
+}
+
+
+
+
+ class TestComponentBase<Cfg extends TestComponent._ = TestComponent._> implements TestInterface {
+
+   static readonly DEFAULT:string = "_DEFAULT_";
+
+   #property_1:string = null;
+   #property_2:int = 0;
+
+   constructor(config:TestComponent._ = null) {
+    this.#property_1 = config.property_1 += "_HI";
+    this.#property_2 = config.property_2 || 0;
+  }
+
+   #component:any = null;
+
+   init(component:any):void {
+    this.#component = component;
+  }
+}
+interface TestComponentBase<Cfg extends TestComponent._ = TestComponent._>extends TestComponentBaseProperties{}
+
+mixin(TestComponentBase, TestInterface);
+
+declare namespace TestComponentBase {
+  export type _ = TestComponentBase_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default TestComponentBase;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/somePackageGlobal.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/somePackageGlobal.ts
@@ -1,0 +1,11 @@
+import SomeOtherClass from './someOtherPackage/SomeOtherClass';
+
+
+// This comment to vanish in API
+
+/**
+ * Some package-global documentation;
+ */
+ var somePackageGlobal:{_: SomeOtherClass}
+  ={_:  new SomeOtherClass()};
+export default somePackageGlobal;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/somePackageGlobalFun.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/somePackageGlobalFun.ts
@@ -1,0 +1,11 @@
+import SomeOtherClass from './someOtherPackage/SomeOtherClass';
+
+
+// This comment to vanish in API
+/**
+ * Some package-global documentation;
+ */
+ function somePackageGlobalFun(flag:boolean):SomeOtherClass {
+  return new SomeOtherClass();
+}
+export default somePackageGlobalFun;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/testNamespace.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/testNamespace.ts
@@ -1,0 +1,8 @@
+
+
+/**
+ * Some ASDoc for the namespace.
+ */
+// this comment should vanish in API!
+ namespace = "http://testNamespace";
+export default testNamespace;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/uninitializedPackageGlobal.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/uninitializedPackageGlobal.ts
@@ -1,0 +1,9 @@
+import SomeOtherClass from './someOtherPackage/SomeOtherClass';
+
+
+// This comment to vanish in API
+/**
+ * Some package-global documentation;
+ */
+ var uninitializedPackageGlobal:{_: SomeOtherClass}={_: null};
+export default uninitializedPackageGlobal;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestEventListener.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestEventListener.ts
@@ -1,0 +1,36 @@
+import {cast} from '@jangaroo/joo/AS3';
+import Panel from '../ext/Panel';
+import PanelEvent from '../ext/events/PanelEvent';
+
+
+ class TestEventListener {
+
+   #panel:Panel = cast(Panel,{});
+  
+   #panels:Array<Panel> = [];
+
+  
+  //@ts-expect-error 18022
+   #getPanels():Array<Panel> {
+    return this.#panels;
+  }
+
+   constructor() {const this$=this;
+    this.#panel.setConfig("title" , "not yet clicked.");
+    this.#panel.addEventListener( PanelEvent.FLOPS, (event:PanelEvent):void => {
+      this.getThis().getPanel().setConfig("title" , "clicked!");
+      this.#panel.layout.getOwner().setConfig("title" , "clicked!");
+      this.#panels.push(this.#panel);
+      this.#getPanels()[0].setConfig("title" , "yes, clicked!");
+    } );
+  }
+
+   getThis():TestEventListener {
+    return this;
+  }
+
+   getPanel():Panel {
+    return this.#panel;
+  }
+}
+export default TestEventListener;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestExtPrivate.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestExtPrivate.ts
@@ -1,0 +1,13 @@
+
+ class TestExtPrivate {
+
+   canOverride():void {
+    // This method can be overridden in subclasses.
+  }
+
+  
+   canOnlyOverrideIfAnnotated(foo:string):boolean {
+    // This method can only be overridden in subclasses if annotated with [ExtPrivate].
+  }
+}
+export default TestExtPrivate;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixin.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixin.ts
@@ -1,0 +1,18 @@
+import {mixin} from '@jangaroo/joo/AS3';
+interface TestMixin_ {
+}
+
+
+ class TestMixin<Cfg extends TestMixin._ = TestMixin._> {
+
+   mix(thing:string):string {
+    return "Mixed " + thing + "!";
+  }
+}
+declare namespace TestMixin {
+  export type _ = TestMixin_;
+  export const _: { new(config?: _): _; };
+}
+
+
+export default TestMixin;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixinClient.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixinClient.ts
@@ -1,0 +1,18 @@
+import {mixin} from '@jangaroo/joo/AS3';
+import TestMixin from './TestMixin';
+
+
+ class TestMixinClient {
+
+   constructor(thing:string) {
+    this.mix(thing);
+  }
+}
+interface TestMixinClient extends TestMixin{
+
+  /** @inheritDoc */
+    mix(thing:string):string;}
+
+mixin(TestMixinClient, TestMixin);
+
+export default TestMixinClient;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixinConfig.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixinConfig.ts
@@ -1,0 +1,47 @@
+
+ class TestMixinConfig {
+
+  
+  //@ts-expect-error 18022
+   #doSomethingBeforeFoo() {
+    // gotcha before foo!
+  }
+
+  
+  protected doSomethingAfterFoo() {
+    // gotcha after foo!
+  }
+
+  
+   doSomethingBeforeBar() {
+    // gotcha before bar!
+  }
+
+  
+   doSomethingOnBar() {
+    // gotcha on bar!
+  }
+
+  
+   doSomethingOnBaz() {
+    // gotcha on baz!
+  }
+
+  
+   doSomethingOnMany() {
+    // gotcha on many!
+  }
+
+  
+  
+   doSomethingOnBoth() {
+    // gotcha on both!
+  }
+
+  
+  //@ts-expect-error 18022
+   static #extendClass(baseClass:Class, derivedClass:Class, classBody: any):void {
+    // gotcha extended!
+  }
+}
+export default TestMixinConfig;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestPrototypeConstants.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestPrototypeConstants.ts
@@ -1,0 +1,9 @@
+
+
+ class TestPrototypeConstants {
+
+  readonly foo:string = "FOO";
+  readonly bar:Record<string,any> = {};
+
+}
+export default TestPrototypeConstants;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestRequireResourceBundle.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestRequireResourceBundle.ts
@@ -1,0 +1,12 @@
+import ResourceBundle_properties from './ResourceBundle_properties';
+import IResourceManager from '../mx/resources/IResourceManager';
+
+
+
+ class TestRequireResourceBundle {
+
+   testResourceManagerAccess(rm:IResourceManager) {
+    var propertyValue = ResourceBundle_properties.someProperty;
+  }
+}
+export default TestRequireResourceBundle;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestStatementStartingWithArrayLiteral.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestStatementStartingWithArrayLiteral.ts
@@ -1,0 +1,12 @@
+import int from '../AS3/int_';
+
+ class TestStatementStartingWithArrayLiteral {
+
+   static sum1_2_3():int {
+    var result = 0;
+    [1, 2, 3].forEach((x:int):void => { result += x; });
+    return result;
+  }
+
+}
+export default TestStatementStartingWithArrayLiteral;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestStaticAccess.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestStaticAccess.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2008 CoreMedia AG
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, 
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+ * express or implied. See the License for the specific language 
+ * governing permissions and limitations under the License.
+ */
+
+import StaticAccessSuperSuperClass from '../package1/StaticAccessSuperSuperClass';
+import StaticAccessSuperClass from './StaticAccessSuperClass';
+
+
+ class TestStaticAccess extends StaticAccessSuperClass {
+
+  static  s1:string = "s1";
+  static 
+  //@ts-expect-error 18022
+ #s2:string = "s2";
+
+   constructor() {
+    super();
+    StaticAccessSuperSuperClass.f0();
+  }
+
+  static  get_s0():string {
+    return StaticAccessSuperClass.s0;
+  }
+ 
+  static  set_s0(_s0:string):void {
+    StaticAccessSuperClass.s0 = _s0;
+  }
+
+  static  get_s0_qualified():string {
+    var s0 = "qualified error";
+    return StaticAccessSuperClass.s0;
+  }
+
+  static  set_s0_qualified(s0:string):void {
+    StaticAccessSuperClass.s0 = s0;
+  }
+
+  static  get_s0_fully_qualified():string {
+    var s0 = "fully qualified error";
+    return StaticAccessSuperClass.s0;
+  }
+
+  static  set_s0_fully_qualified(s0:string):void {
+    StaticAccessSuperClass.s0 = s0;
+  }
+
+  static  get_s1():string {
+      return TestStaticAccess.s1;
+    }
+  
+  static  set_s1(_s1:string):void {
+    TestStaticAccess.s1 = _s1;
+  }
+
+  static  get_s1_qualified():string {
+    var s1 = "qualified error";
+    return TestStaticAccess.s1;
+  }
+
+  static  set_s1_qualified(s1:string):void {
+    TestStaticAccess.s1 = s1;
+  }
+
+  static  get_s1_fully_qualified():string {
+    var s1 = "fully qualified error";
+    return TestStaticAccess.s1;
+  }
+
+  static  set_s1_fully_qualified(s1:string):void {
+    TestStaticAccess.s1 = s1;
+  }
+
+  static  get_s2():string {
+    return TestStaticAccess.#s2;
+  }
+
+  static  set_s2(_s2:string):void {
+    TestStaticAccess.#s2 = _s2;
+  }
+
+  static  get_s2_qualified():string {
+    var s2 = "qualified error";
+    return TestStaticAccess.#s2;
+  }
+
+  static  set_s2_qualified(s2:string):void {
+    TestStaticAccess.#s2 = s2;
+  }
+
+  static  get_s2_fully_qualified():string {
+    var s2 = "fully qualified error";
+    return TestStaticAccess.#s2;
+  }
+
+  static  set_s2_fully_qualified(s2:string):void {
+    TestStaticAccess.#s2 = s2;
+  }
+
+  static 
+  //@ts-expect-error 18022
+ #get_s2_private():string {
+    return TestStaticAccess.#s2;
+  }
+
+  static  get_s2_via_private_static_method():string {
+    return TestStaticAccess.#get_s2_private();
+  }
+
+  static  get_s2_via_private_static_method_qualified():string {
+    return TestStaticAccess.#get_s2_private();
+  }
+
+  static  get_s2_via_private_static_method_full_qualified():string {
+    TestStaticAccess.#some_private_static = TestStaticAccess.#some_private_static + "foo";
+    return TestStaticAccess.#get_s2_private();
+  }
+
+  //@ts-expect-error 18022
+   static get #some_private_static():string {
+    return "some_private_static";
+  }
+
+  //@ts-expect-error 18022
+   static set #some_private_static(value:string) {
+  }
+}
+export default TestStaticAccess;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/testPackage/PropertiesTest_properties.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/testPackage/PropertiesTest_properties.ts
@@ -1,0 +1,24 @@
+import MoreIcons_properties from "./MoreIcons_properties";
+import Icons_properties from "./Icons_properties";
+
+/**
+ * some comment
+ * [PublicApi]
+ */
+interface PropertiesTest_properties {
+  key: string;
+  key2: string;
+  key3: string;
+  "keyWith\"+\"quotes": string;
+  "keyWith\"+\"quotesAndReference": string;
+}
+
+const PropertiesTest_properties: PropertiesTest_properties = {
+  key: "The disk \"{1}\" contains {0}.",
+  key2: Icons_properties.someKey,
+  key3: MoreIcons_properties.someOtherKey,
+  "keyWith\"+\"quotes": "gotcha!",
+  "keyWith\"+\"quotesAndReference": MoreIcons_properties.someOtherKey,
+};
+
+export default PropertiesTest_properties;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/testPackage/PropertiesTest_properties_de.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/testPackage/PropertiesTest_properties_de.ts
@@ -1,0 +1,5 @@
+import PropertiesTest_properties from "./PropertiesTest_properties";
+
+ResourceBundleUtil.override(PropertiesTest_properties, {
+  key: "Die Platte \"{1}\" enthält {0}.",
+});

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/testPackage/PropertiesTest_properties_es_ES.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/testPackage/PropertiesTest_properties_es_ES.ts
@@ -1,0 +1,5 @@
+import PropertiesTest_properties from "./PropertiesTest_properties";
+
+ResourceBundleUtil.override(PropertiesTest_properties, {
+  key: "Hasta la vista",
+});

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/testPackage/PropertiesTest_properties_it_VA_WIN.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/testPackage/PropertiesTest_properties_it_VA_WIN.ts
@@ -1,0 +1,5 @@
+import PropertiesTest_properties from "./PropertiesTest_properties";
+
+ResourceBundleUtil.override(PropertiesTest_properties, {
+  key: "Mama mia",
+});

--- a/jangaroo/jangaroo-compiler/src/test/resources/expectedProperties/en/testPackage/PropertiesTest_properties.js
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expectedProperties/en/testPackage/PropertiesTest_properties.js
@@ -5,15 +5,15 @@
 Ext.define("testPackage.PropertiesTest_properties", {
 
   requires: [
-    "net.jangaroo.icons.SomeBundle_properties",
-    "net.jangaroo.SomeOtherBundle_properties"
+    "testPackage.MoreIcons_properties",
+    "testPackage.Icons_properties"
   ],
   "key": "The disk \"{1}\" contains {0}.",
   "keyWith\"+\"quotes": "gotcha!"
 }, function() {
-  this.prototype["key2"] =  net.jangaroo.icons.SomeBundle_properties.INSTANCE.someKey;
-  this.prototype["key3"] =  net.jangaroo.SomeOtherBundle_properties.INSTANCE.someOtherKey;
-  this.prototype["keyWith\"+\"quotesAndReference"] =  net.jangaroo.SomeOtherBundle_properties.INSTANCE.someOtherKey;
+  this.prototype["key2"] =  testPackage.Icons_properties.INSTANCE.someKey;
+  this.prototype["key3"] =  testPackage.MoreIcons_properties.INSTANCE.someOtherKey;
+  this.prototype["keyWith\"+\"quotesAndReference"] =  testPackage.MoreIcons_properties.INSTANCE.someOtherKey;
 
   testPackage.PropertiesTest_properties.INSTANCE = new testPackage.PropertiesTest_properties();
 });

--- a/jangaroo/jangaroo-compiler/src/test/resources/testPackage/Icons.properties
+++ b/jangaroo/jangaroo-compiler/src/test/resources/testPackage/Icons.properties
@@ -1,0 +1,1 @@
+someKey = icon.png

--- a/jangaroo/jangaroo-compiler/src/test/resources/testPackage/MoreIcons.properties
+++ b/jangaroo/jangaroo-compiler/src/test/resources/testPackage/MoreIcons.properties
@@ -1,0 +1,1 @@
+someOtherKey = someOtherIcon.png

--- a/jangaroo/jangaroo-compiler/src/test/resources/testPackage/PropertiesTest.properties
+++ b/jangaroo/jangaroo-compiler/src/test/resources/testPackage/PropertiesTest.properties
@@ -2,7 +2,7 @@
 # [PublicApi]
 
 key=The disk \"{1}\" contains {0}.
-key2=Resource(key='someKey', bundle='net.jangaroo.icons.SomeBundle')
-key3=Resource(key='someOtherKey', bundle='net.jangaroo.SomeOtherBundle')
+key2=Resource(key='someKey', bundle='testPackage.Icons')
+key3=Resource(key='someOtherKey', bundle='testPackage.MoreIcons')
 keyWith"+"quotes = gotcha!
-keyWith"+"quotesAndReference = Resource(key='someOtherKey', bundle='net.jangaroo.SomeOtherBundle')
+keyWith"+"quotesAndReference = Resource(key='someOtherKey', bundle='testPackage.MoreIcons')


### PR DESCRIPTION
Enable most compiler integration tests to also be executed in migrateToTypeScript mode.