### PR TITLE
[TS] Use @mixin / @metadata decorators instead of method calls

### DIFF
--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ImplementsInterface.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ImplementsInterface.ts
@@ -3,6 +3,7 @@ import Interface from './Interface';
 import Panel from '../ext/Panel';
 
 
+@mixin(Interface)
 class ImplementsInterface implements Interface {
 
   /**
@@ -36,6 +37,4 @@ class ImplementsInterface implements Interface {
     this.foo = value.substr("prefix".length);
   }
 }
-mixin(ImplementsInterface, Interface);
-
 export default ImplementsInterface;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/NoCodeExpression.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/NoCodeExpression.ts
@@ -1,7 +1,6 @@
 import {metadata} from '@jangaroo/joo/AS3';
 
+@metadata("RemoteClass", "{this is not a code expression}", { alias: "{this is also not a code expression}"})
 class NoCodeExpression {
 }
-metadata(NoCodeExpression, ["RemoteClass", {"": "{this is not a code expression}",  alias: "{this is also not a code expression}"}]);
-
 export default NoCodeExpression;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/UsingEmbed.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/UsingEmbed.ts
@@ -4,6 +4,8 @@ import Bitmap from '../flash/display/Bitmap';
 /**
  * This is an example of a class using an [Embed] annotation.
  */
+@metadata("SomeRuntimeAnnotation")
+@metadata("SomeRuntimeAnnotation", {foo: "bar"})
 class UsingEmbed {
 
   someText:Class = null;
@@ -38,7 +40,4 @@ class UsingEmbed {
   annotated6:string;
 
 }
-metadata(UsingEmbed, ["SomeRuntimeAnnotation"],
-    "SomeRuntimeAnnotation", {foo: "bar"}]);
-
 export default UsingEmbed;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/InterfaceImplementingMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/InterfaceImplementingMxmlClass.ts
@@ -10,6 +10,7 @@ interface InterfaceImplementingMxmlClass_ extends ConfigClass._, Partial<Pick<In
 }
 
 
+@mixin(YetAnotherInterface)
 class InterfaceImplementingMxmlClass<Cfg extends InterfaceImplementingMxmlClass._ = InterfaceImplementingMxmlClass._> extends ConfigClass<Cfg> implements YetAnotherInterface{
 
     constructor(config:InterfaceImplementingMxmlClass._ = null){
@@ -27,8 +28,6 @@ class InterfaceImplementingMxmlClass<Cfg extends InterfaceImplementingMxmlClass.
 interface InterfaceImplementingMxmlClass<Cfg extends InterfaceImplementingMxmlClass._ = InterfaceImplementingMxmlClass._>{
 
     createInstance(o:SimpleInterface):SimpleClass;}
-
-mixin(InterfaceImplementingMxmlClass, YetAnotherInterface);
 
 declare namespace InterfaceImplementingMxmlClass {
   export type _ = InterfaceImplementingMxmlClass_;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataCdataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataCdataMxmlClass.ts
@@ -10,13 +10,12 @@ interface MetadataCdataMxmlClass_ extends ConfigClass._ {
      * Let's have a class with two annotations.
      * @see {@link http://help.adobe.com/en_US/flex/using/WSd0ded3821e0d52fe1e63e3d11c2f44bc36-7ff2.html}
      */
-    class MetadataCdataMxmlClass<Cfg extends MetadataCdataMxmlClass._ = MetadataCdataMxmlClass._> extends ConfigClass<Cfg>{constructor(config:MetadataCdataMxmlClass._=null){
+    @metadata("ThisIsJustATest")
+@metadata("Deprecated", {replacement: 'use.this.please'})
+class MetadataCdataMxmlClass<Cfg extends MetadataCdataMxmlClass._ = MetadataCdataMxmlClass._> extends ConfigClass<Cfg>{constructor(config:MetadataCdataMxmlClass._=null){
     super( Exml.apply(new MetadataCdataMxmlClass._({
 }),config));
 }}
-metadata(MetadataCdataMxmlClass, ["ThisIsJustATest"],
-    "Deprecated", {replacement: 'use.this.please'}]);
-
 declare namespace MetadataCdataMxmlClass {
   export type _ = MetadataCdataMxmlClass_;
   export const _: { new(config?: _): _; };

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataMxmlClass.ts
@@ -6,13 +6,12 @@ interface MetadataMxmlClass_ extends ConfigClass._ {
 
 
 
-    class MetadataMxmlClass<Cfg extends MetadataMxmlClass._ = MetadataMxmlClass._> extends ConfigClass<Cfg>{constructor(config:MetadataMxmlClass._=null){
+    @metadata("ThisIsJustATest")
+@metadata("Deprecated", {replacement: 'use.this.please'})
+class MetadataMxmlClass<Cfg extends MetadataMxmlClass._ = MetadataMxmlClass._> extends ConfigClass<Cfg>{constructor(config:MetadataMxmlClass._=null){
     super( Exml.apply(new MetadataMxmlClass._({
 }),config));
 }}
-metadata(MetadataMxmlClass, ["ThisIsJustATest"],
-    "Deprecated", {replacement: 'use.this.please'}]);
-
 declare namespace MetadataMxmlClass {
   export type _ = MetadataMxmlClass_;
   export const _: { new(config?: _): _; };

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/ScriptCdataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/ScriptCdataMxmlClass.ts
@@ -10,6 +10,7 @@ interface ScriptCdataMxmlClass_ extends ConfigClass._, Partial<Pick<ScriptCdataM
 }
 
 
+@mixin(SimpleInterface)
 class ScriptCdataMxmlClass<Cfg extends ScriptCdataMxmlClass._ = ScriptCdataMxmlClass._> extends ConfigClass<Cfg> implements SimpleInterface{
 
     #field1:SomeOtherClass = null;
@@ -25,8 +26,6 @@ class ScriptCdataMxmlClass<Cfg extends ScriptCdataMxmlClass._ = ScriptCdataMxmlC
              foo: "bar"
 }),config));
 }}
-mixin(ScriptCdataMxmlClass, SimpleInterface);
-
 declare namespace ScriptCdataMxmlClass {
   export type _ = ScriptCdataMxmlClass_;
   export const _: { new(config?: _): _; };

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMetadataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMetadataMxmlClass.ts
@@ -5,12 +5,11 @@ interface SimpleMetadataMxmlClass_ extends ConfigClass._ {
 }
 
 
+@metadata("ShortVersion")
 class SimpleMetadataMxmlClass<Cfg extends SimpleMetadataMxmlClass._ = SimpleMetadataMxmlClass._> extends ConfigClass<Cfg>{constructor(config:SimpleMetadataMxmlClass._=null){
     super( Exml.apply(new SimpleMetadataMxmlClass._({
 }),config));
 }}
-metadata(SimpleMetadataMxmlClass, ["ShortVersion"]);
-
 declare namespace SimpleMetadataMxmlClass {
   export type _ = SimpleMetadataMxmlClass_;
   export const _: { new(config?: _): _; };

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponentBase.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponentBase.ts
@@ -11,6 +11,7 @@ interface TestComponentBase_ extends Partial<Pick<TestComponentBase,
 
 
 
+@mixin(TestInterface)
 class TestComponentBase<Cfg extends TestComponent._ = TestComponent._> implements TestInterface {
 
   static readonly DEFAULT:string = "_DEFAULT_";
@@ -32,8 +33,6 @@ class TestComponentBase<Cfg extends TestComponent._ = TestComponent._> implement
     this.#component = component;
   }
 }
-mixin(TestComponentBase, TestInterface);
-
 declare namespace TestComponentBase {
   export type _ = TestComponentBase_;
   export const _: { new(config?: _): _; };

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixinClient.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixinClient.ts
@@ -2,6 +2,7 @@ import {mixin} from '@jangaroo/joo/AS3';
 import TestMixin from './TestMixin';
 
 
+@mixin(TestMixin)
 class TestMixinClient {
 
   constructor(thing:string) {
@@ -9,7 +10,5 @@ class TestMixinClient {
   }
 }
 interface TestMixinClient extends TestMixin{}
-
-mixin(TestMixinClient, TestMixin);
 
 export default TestMixinClient;


### PR DESCRIPTION
The decorator is directly in front the class declaration and
does not have to repeat the class name.
While simplifying the syntax, also allowed metadata default
parameters to be used directly instead of using an empty
string ("") as object key.