### PR TITLE
Move dependency warnings from compiler to maven plugin

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
@@ -182,11 +182,11 @@ public abstract class AbstractCompilerMojo extends AbstractJangarooMojo {
    * In ECMAScript, initializer values are assigned to all 'undefined' arguments.
    * In AS3, initializer values are assigned only if you call a method with less arguments.
    * An example would be
-   *    function foo(bar: string = "default"): string {
-   *      return bar;
-   *    }
-   *    foo(); // "default" for both AS3 and ECMAScript semantics
-   *    foo(undefined); // 'undefined' in AS3, "default" in ECMAScript semantics
+   *     function foo(bar: string = "default"): string {
+   *       return bar;
+   *     }
+   *     foo(); // "default" for both AS3 and ECMAScript semantics
+   *     foo(undefined); // 'undefined' in AS3, "default" in ECMAScript semantics
    */
   @Parameter(property = "maven.compiler.useEcmaParameterInitializerSemantics")
   private boolean useEcmaParameterInitializerSemantics = false;
@@ -301,8 +301,12 @@ public abstract class AbstractCompilerMojo extends AbstractJangarooMojo {
 
     int result = compile(jooc);
 
-    printDependencyWarnings(configuration);
-    Paths.get(configuration.getWarningsOutputDirectory(), "dependencyWarnings").toFile().delete();
+    if (configuration.getDependencyReportOutputFile() == null) {
+      log.warn("No directory for dependency warnings specified, ignoring dependency warnings.");
+    } else {
+      printDependencyWarnings(configuration);
+      new File(configuration.getDependencyReportOutputFile()).delete();
+    }
     if ((result != CompilationResult.RESULT_CODE_OK) && failOnError) {
       log.info("-------------------------------------------------------------");
       if (result == CompilationResult.RESULT_CODE_COMPILATION_FAILED) {
@@ -398,7 +402,7 @@ public abstract class AbstractCompilerMojo extends AbstractJangarooMojo {
     configuration.setApiOutputDirectory(getApiOutputDirectory());
     configuration.setFindUnusedDependencies(findUnusedDependencies(staleMillis));
     //todo: use proper directory
-    configuration.setWarningsOutputDirectory("dependencyWarnings");
+    configuration.setDependencyReportOutputFile("target/dependencyReports/dependencyWarnings");
 
     configuration.setSassSourceFilesByType(sassSourceFilesByType);
     try {

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/AbstractCompilerMojo.java
@@ -402,7 +402,7 @@ public abstract class AbstractCompilerMojo extends AbstractJangarooMojo {
     configuration.setApiOutputDirectory(getApiOutputDirectory());
     configuration.setFindUnusedDependencies(findUnusedDependencies(staleMillis));
     //todo: use proper directory
-    configuration.setDependencyReportOutputFile("target/dependencyReports/dependencyWarnings");
+    configuration.setDependencyReportOutputFile("target/dependencyReports/dependencyWarnings.txt");
 
     configuration.setSassSourceFilesByType(sassSourceFilesByType);
     try {

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/CompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/CompilerMojo.java
@@ -2,6 +2,8 @@ package net.jangaroo.jooc.mvnplugin;
 
 import net.jangaroo.jooc.config.JoocConfiguration;
 import net.jangaroo.jooc.mvnplugin.sencha.SenchaUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -11,9 +13,14 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -116,13 +123,34 @@ public class CompilerMojo extends AbstractCompilerMojo {
   }
 
   @Override
-  protected boolean findUnusedDependencies() {
-    return true;
+  protected void printDependencyWarnings(JoocConfiguration joocConfiguration) {
+    File dependencyWarningsFile = Paths.get(joocConfiguration.getWarningsOutputDirectory(), "dependencyWarnings").toFile();
+    if (dependencyWarningsFile.exists()) {
+      try {
+        Map<String, Object> dependencyWarnings = SenchaUtils.getObjectMapper().readValue(FileUtils.readFileToString(dependencyWarningsFile), Map.class);
+
+        if (joocConfiguration.isFindUnusedDependencies() && dependencyWarnings.get("unusedDependencies") instanceof List) {
+          printUnusedDependencyWarnings(joocConfiguration, (List<String>) dependencyWarnings.get("unusedDependencies"));
+        }
+        if (dependencyWarnings.get("undeclaredDependencies") instanceof List) {
+          printUndeclaredDependencyWarnings(joocConfiguration, (List<String>) dependencyWarnings.get("undeclaredDependencies"), "");
+        }
+      } catch (IOException e) {
+        getLog().error(String.format("There was an error while reading file %s", dependencyWarningsFile.getPath()));
+      }
+    }
   }
 
   @Override
-  protected boolean isTestRun() {
-    return false;
+  protected List<String> createUsedUndeclaredDependencyWarning(Artifact dependency) {
+    List<String> lines = new ArrayList<>();
+      lines.add("<dependency>");
+      lines.add(String.format("  <groupId>%s</groupId>", dependency.getGroupId()));
+      lines.add(String.format("  <artifactId>%s</artifactId>", dependency.getArtifactId()));
+      lines.add(String.format("  <version>%s</version>", dependency.getVersion()));
+      lines.add("  <type>swc</type>");
+      lines.add("</dependency>");
+    return lines;
   }
 
   private File getPackageOutputDirectory() {

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/CompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/CompilerMojo.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -124,7 +123,7 @@ public class CompilerMojo extends AbstractCompilerMojo {
 
   @Override
   protected void printDependencyWarnings(JoocConfiguration joocConfiguration) {
-    File dependencyWarningsFile = Paths.get(joocConfiguration.getWarningsOutputDirectory(), "dependencyWarnings").toFile();
+    File dependencyWarningsFile = new File(joocConfiguration.getDependencyReportOutputFile());
     if (dependencyWarningsFile.exists()) {
       try {
         Map<String, Object> dependencyWarnings = SenchaUtils.getObjectMapper().readValue(FileUtils.readFileToString(dependencyWarningsFile), Map.class);

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/TestCompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/TestCompilerMojo.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -136,7 +135,7 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
 
   @Override
   protected void printDependencyWarnings(JoocConfiguration joocConfiguration) {
-    File dependencyWarningsFile = Paths.get(joocConfiguration.getWarningsOutputDirectory(), "dependencyWarnings").toFile();
+    File dependencyWarningsFile = new File(joocConfiguration.getDependencyReportOutputFile());
     if (dependencyWarningsFile.exists()) {
       try {
         Map<String, Object> dependencyWarnings = SenchaUtils.getObjectMapper().readValue(FileUtils.readFileToString(dependencyWarningsFile), Map.class);

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/TestCompilerMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/TestCompilerMojo.java
@@ -1,5 +1,9 @@
 package net.jangaroo.jooc.mvnplugin;
 
+import net.jangaroo.jooc.config.JoocConfiguration;
+import net.jangaroo.jooc.mvnplugin.sencha.SenchaUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -8,10 +12,14 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -68,7 +76,6 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
   protected boolean skip;
 
   /**
-   * 
    * @return null as API stub generation does not make sense for test sources
    */
   @Override
@@ -123,12 +130,39 @@ public class TestCompilerMojo extends AbstractCompilerMojo {
   }
 
   @Override
-  protected boolean findUnusedDependencies() {
+  protected boolean findUnusedDependencies(int staleMillis) {
     return false;
   }
 
   @Override
-  protected boolean isTestRun() {
-    return true;
+  protected void printDependencyWarnings(JoocConfiguration joocConfiguration) {
+    File dependencyWarningsFile = Paths.get(joocConfiguration.getWarningsOutputDirectory(), "dependencyWarnings").toFile();
+    if (dependencyWarningsFile.exists()) {
+      try {
+        Map<String, Object> dependencyWarnings = SenchaUtils.getObjectMapper().readValue(FileUtils.readFileToString(dependencyWarningsFile), Map.class);
+
+        if (joocConfiguration.isFindUnusedDependencies() && dependencyWarnings.get("unusedDependencies") instanceof List) {
+          printUnusedDependencyWarnings(joocConfiguration, (List<String>) dependencyWarnings.get("unusedDependencies"));
+        }
+        if (dependencyWarnings.get("undeclaredDependencies") instanceof List) {
+          printUndeclaredDependencyWarnings(joocConfiguration, (List<String>) dependencyWarnings.get("undeclaredDependencies"), "test-");
+        }
+      } catch (IOException e) {
+        getLog().error(String.format("There was an error while reading file %s", dependencyWarningsFile.getPath()));
+      }
+    }
+  }
+
+  @Override
+  protected List<String> createUsedUndeclaredDependencyWarning(Artifact dependency) {
+    List<String> lines = new ArrayList<>();
+      lines.add("<dependency>");
+      lines.add(String.format("  <groupId>%s</groupId>", dependency.getGroupId()));
+      lines.add(String.format("  <artifactId>%s</artifactId>", dependency.getArtifactId()));
+      lines.add(String.format("  <version>%s</version>", dependency.getVersion()));
+      lines.add("  <type>swc</type>");
+      lines.add("  <scope>test</scope>");
+      lines.add("</dependency>");
+    return lines;
   }
 }

--- a/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocConfiguration.java
+++ b/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocConfiguration.java
@@ -46,6 +46,7 @@ public class JoocConfiguration extends FileLocations implements JoocOptions, Par
 
   private boolean findUnusedDependencies;
   private boolean sourcesAreTests;
+  private String dependencyWarningsOutputDirectory;
 
   public SemicolonInsertionMode getSemicolonInsertionMode() {
     return semicolonInsertionMode;
@@ -290,12 +291,12 @@ public class JoocConfiguration extends FileLocations implements JoocOptions, Par
   }
 
   @Override
-  public boolean isSourcesAreTests() {
-    return this.sourcesAreTests;
+  public String getWarningsOutputDirectory() {
+    return this.dependencyWarningsOutputDirectory;
   }
 
-  @Option(name = "--sourcesAreTests", usage = "Specify that the source to compile (sourcePath) are test code. This is relevant for dependency checks, especially for reporting unused dependencies, as Maven does not distinguish between test compile and test runtime dependencies.")
-  public void setSourcesAreTests(boolean sourcesAreTests) {
-    this.sourcesAreTests = sourcesAreTests;
+  @Option(name = "--warningsOutputDirectory", usage = "the directory to use for saving the dependency warnings")
+  public void setWarningsOutputDirectory(String warningsOutputDirectory) {
+    this.dependencyWarningsOutputDirectory = warningsOutputDirectory;
   }
 }

--- a/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocConfiguration.java
+++ b/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocConfiguration.java
@@ -46,7 +46,7 @@ public class JoocConfiguration extends FileLocations implements JoocOptions, Par
 
   private boolean findUnusedDependencies;
   private boolean sourcesAreTests;
-  private String dependencyWarningsOutputDirectory;
+  private String dependencyReportOutputFile;
 
   public SemicolonInsertionMode getSemicolonInsertionMode() {
     return semicolonInsertionMode;
@@ -291,12 +291,12 @@ public class JoocConfiguration extends FileLocations implements JoocOptions, Par
   }
 
   @Override
-  public String getWarningsOutputDirectory() {
-    return this.dependencyWarningsOutputDirectory;
+  public String getDependencyReportOutputFile() {
+    return this.dependencyReportOutputFile;
   }
 
-  @Option(name = "--warningsOutputDirectory", usage = "the directory to use for saving the dependency warnings")
-  public void setWarningsOutputDirectory(String warningsOutputDirectory) {
-    this.dependencyWarningsOutputDirectory = warningsOutputDirectory;
+  @Option(name = "--dependencyReportOutputFile", usage = "the file to use for saving the dependency warnings. In order to execute the dependency checks, this need to be set.")
+  public void setDependencyReportOutputFile(String dependencyReportOutputFile) {
+    this.dependencyReportOutputFile = dependencyReportOutputFile;
   }
 }

--- a/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocOptions.java
+++ b/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocOptions.java
@@ -38,7 +38,7 @@ public interface JoocOptions {
 
   boolean isFindUnusedDependencies();
 
-  String getWarningsOutputDirectory();
+  String getDependencyReportOutputFile();
 
   File getKeepGeneratedActionScriptDirectory();
 }

--- a/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocOptions.java
+++ b/jangaroo-tools-api/jangaroo-compiler-api/src/main/java/net/jangaroo/jooc/config/JoocOptions.java
@@ -38,7 +38,7 @@ public interface JoocOptions {
 
   boolean isFindUnusedDependencies();
 
-  boolean isSourcesAreTests();
+  String getWarningsOutputDirectory();
 
   File getKeepGeneratedActionScriptDirectory();
 }

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/DependencyWarningsManager.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/DependencyWarningsManager.java
@@ -2,26 +2,17 @@ package net.jangaroo.jooc;
 
 import net.jangaroo.jooc.input.InputSource;
 import net.jangaroo.jooc.input.PathInputSource;
-import net.jangaroo.jooc.input.ZipEntryInputSource;
-import net.jangaroo.jooc.input.ZipFileInputSource;
+import net.jangaroo.jooc.json.JsonArray;
+import net.jangaroo.jooc.json.JsonObject;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 public class DependencyWarningsManager {
   private final List<DependencyWarning> dependencyWarnings;
@@ -39,7 +30,7 @@ public class DependencyWarningsManager {
   private void getCompileDependencies(PathInputSource classPathInputSource) {
     for (InputSource child : classPathInputSource.getChildren("")) {
       if (child.isInCompilePath()) {
-        String key = convertInputSourceToDependency(child);
+        String key = child.getPath().split("!")[0];
         if (key != null) {
           compileDependencies.putIfAbsent(key, false);
         }
@@ -47,53 +38,14 @@ public class DependencyWarningsManager {
     }
   }
 
-  public String convertInputSourceToDependency(InputSource inputSource) {
-    ZipFile zipFile;
-    if (inputSource instanceof ZipFileInputSource) {
-      zipFile = ((ZipFileInputSource) inputSource).getZipFile();
-    } else if (inputSource instanceof ZipEntryInputSource) {
-      zipFile = ((ZipEntryInputSource) inputSource).getZipFileInputSource().getZipFile();
-    } else {
-      return inputSource.getPath();
-    }
-    return handleZipFile(zipFile);
+  public List<DependencyWarning> getDependencyWarnings() {
+    return dependencyWarnings;
   }
 
-  private String handleZipFile(ZipFile zipFile) {
-    CompileDependency compileDependency = new CompileDependency();
-    Enumeration<? extends ZipEntry> entries = zipFile.entries();
-    ZipEntry zipEntry = null;
-    while (entries.hasMoreElements()) {
-      ZipEntry nextElement = entries.nextElement();
-      if (nextElement.getName().contains("META-INF/maven") && nextElement.getName().contains("pom.properties")) {
-        zipEntry = nextElement;
-      }
-    }
-    if (zipEntry != null) {
-      try (InputStream inputStream = zipFile.getInputStream(zipEntry);
-           InputStreamReader inputStreamReader = new InputStreamReader(inputStream)) {
-        BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
-        String line;
-        while (bufferedReader.ready()) {
-          line = bufferedReader.readLine();
-          setCompileDependency(compileDependency, line);
-        }
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-    }
-    return compileDependency.createString();
-  }
-
-  private void setCompileDependency(CompileDependency dependency, String line) {
-    if (line.contains("artifactId")) {
-      dependency.setArtifactId(line.replace("artifactId=", ""));
-    } else if (line.contains("groupId")) {
-      dependency.setGroupId(line.replace("groupId=", ""));
-    } else if (line.contains("version")) {
-      dependency.setVersion(line.replace("version=", ""));
-    }
-    // only change something if the line contains the correct key, hence no final else branch
+  public String createFileString() {
+    List<String> undeclaredDependencies = dependencyWarnings.stream().map(DependencyWarning::getDependency).collect(Collectors.toList());
+    return new JsonObject("undeclaredDependencies", new JsonArray(undeclaredDependencies.toArray()),
+            "unusedDependencies", new JsonArray(getUnusedDeclaredDependencies().toArray())).toString(2, 0, true);
   }
 
   public void addDependencyWarning(String compileDependency, String usageName) {
@@ -123,10 +75,6 @@ public class DependencyWarningsManager {
     }
   }
 
-  public List<DependencyWarning> getDependencyWarnings() {
-    return dependencyWarnings;
-  }
-
   public List<String> getUnusedDeclaredDependencies() {
     return compileDependencies.entrySet().stream()
             .filter(entry -> !entry.getValue())
@@ -134,88 +82,14 @@ public class DependencyWarningsManager {
             .collect(Collectors.toList());
   }
 
-  public static class CompileDependency {
-    private String artifactId;
-    private String groupId;
-    private String version;
-
-    public CompileDependency() {
-    }
-
-    public CompileDependency(String dependency) {
-      String[] firstSplit = dependency.split("__");
-      if (firstSplit.length == 2) {
-        setGroupId(firstSplit[0]);
-        String[] finalSplit = firstSplit[1].split(":");
-        if (finalSplit.length == 2) {
-          setArtifactId(finalSplit[0]);
-          setVersion(finalSplit[1]);
-        }
-      }
-    }
-
-    public boolean matches(CompileDependency anotherDependency) {
-      return artifactId.equals(anotherDependency.getGroupId()) &&
-              groupId.equals(anotherDependency.getArtifactId()) &&
-              version.equals(anotherDependency.getVersion());
-    }
-
-    public String createString() {
-      return groupId + "__" + artifactId + ":" + version;
-    }
-
-    public String getArtifactId() {
-      return artifactId;
-    }
-
-    public void setArtifactId(String artifactId) {
-      this.artifactId = artifactId;
-    }
-
-    public String getGroupId() {
-      return groupId;
-    }
-
-    public void setGroupId(String groupId) {
-      this.groupId = groupId;
-    }
-
-    public String getVersion() {
-      return version;
-    }
-
-    public void setVersion(String version) {
-      this.version = version;
-    }
-  }
-
   public static class DependencyWarning {
     private final String dependency;
     private final Set<String> usages;
 
     public DependencyWarning(String dependency, String usage) {
-      this.dependency = dependency;
+      this.dependency = dependency.split("!")[0];
       this.usages = new HashSet<>();
-      this.usages.add(usage);
-    }
-
-
-    public List<String> createUsedUndeclaredDependencyWarning(boolean isTestCompile) {
-      CompileDependency compileDependency = new CompileDependency(dependency);
-      if (compileDependency.getArtifactId() == null || compileDependency.getGroupId() == null || compileDependency.getVersion() == null) {
-        return Collections.singletonList(dependency);
-      }
-      List<String> lines = new ArrayList<>();
-      lines.add("<dependency>");
-      lines.add(String.format("  <groupId>%s</groupId>", compileDependency.getGroupId()));
-      lines.add(String.format("  <artifactId>%s</artifactId>", compileDependency.getArtifactId()));
-      lines.add(String.format("  <version>%s</version>", compileDependency.getVersion()));
-      lines.add("  <type>swc</type>");
-      if (isTestCompile) {
-        lines.add("  <scope>test</scope>");
-      }
-      lines.add("</dependency>");
-      return lines;
+      this.usages.add(usage.split("!")[0]);
     }
 
     public String getDependency() {
@@ -227,7 +101,7 @@ public class DependencyWarningsManager {
     }
 
     public boolean matches(String dependency) {
-      return this.dependency.equals(dependency);
+      return this.dependency.equals(dependency.split("!")[0]);
     }
 
     public void addUsage(String usage) {

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/Jooc.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/Jooc.java
@@ -338,15 +338,17 @@ public class Jooc extends JangarooParser implements net.jangaroo.jooc.api.Jooc {
 
       copySassFiles();
 
-      File dependencyWarningsFile = Paths.get(getConfig().getWarningsOutputDirectory(), "dependencyWarnings").toFile();
-      if (!dependencyWarningsFile.getParentFile().exists()) {
-        dependencyWarningsFile.getParentFile().mkdirs();
-      }
-      if (!dependencyWarningsFile.exists()) {
-        dependencyWarningsFile.createNewFile();
-      }
-      try (FileWriter fileWriter = new FileWriter(dependencyWarningsFile)) {
-        fileWriter.write(dependencyWarningsManager.createFileString());
+      if (getConfig().getDependencyReportOutputFile() != null) {
+        File dependencyWarningsFile = new File(getConfig().getDependencyReportOutputFile());
+        if (!dependencyWarningsFile.getParentFile().exists()) {
+          dependencyWarningsFile.getParentFile().mkdirs();
+        }
+        if (!dependencyWarningsFile.exists()) {
+          dependencyWarningsFile.createNewFile();
+        }
+        try (FileWriter fileWriter = new FileWriter(dependencyWarningsFile)) {
+          fileWriter.write(dependencyWarningsManager.createFileString());
+        }
       }
 
       int result = log.hasErrors() ? CompilationResult.RESULT_CODE_COMPILATION_FAILED : CompilationResult.RESULT_CODE_OK;


### PR DESCRIPTION
* Pass dependency warnings via a file from compiler to maven plugin
* introduce a "warningsOutputDirectory" to the compiler to specify where
  to save dependency warnings
* delete isTestCompile option in compiler
* maven plugin is now responsible for displaying error messages