### PR TITLE
[TS] Change Config Constructor back to Factory Function

### DIFF
--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptCodeGenerator.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptCodeGenerator.java
@@ -429,7 +429,7 @@ public class TypeScriptCodeGenerator extends CodeGeneratorBase {
       if (hasConfigClass) {
         out.write(String.format("\ndeclare namespace %s {\n", classDeclarationLocalName));
         out.write(String.format("  export type _ = %s_;\n", classDeclarationLocalName));
-        out.write("  export const _: { new(config?: _): _; };\n");
+        out.write("  export const _: (config?: _) => _;\n");
         out.write("}\n\n");
       }
     }
@@ -1340,7 +1340,7 @@ public class TypeScriptCodeGenerator extends CodeGeneratorBase {
       if (declaration instanceof ClassDeclaration && ((ClassDeclaration) declaration).hasConfigClass()) {
         if (isOfConfigType(args.getExpr().getHead())) {
           // use config factory function instead of the class itself:
-          writeSymbolReplacement(applyExpr.getSymbol(), "new " + compilationUnitAccessCode(declaration) + "._");
+          writeSymbolReplacement(applyExpr.getSymbol(), compilationUnitAccessCode(declaration) + "._");
           args.visit(this);
           return;
         }

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AllElements.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AllElements.ts
@@ -54,7 +54,7 @@ class AllElements extends panel{
       { header: "a", sortable: false, menuDisabled: true},
       { header: "b", sortable: true, menuDisabled: false}
     ];
-    return  Exml.apply(new AllElements._({
+    return  Exml.apply(AllElements._({
            title: "I am a panel",
            layout: Exml.asString( config.#myProperty),
 
@@ -134,7 +134,7 @@ class AllElements extends panel{
   set gear(value:any) { this.#gear = value; }}
 declare namespace AllElements {
   export type _ = AllElements_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ConfigClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/ConfigClass.ts
@@ -37,7 +37,7 @@ class ConfigClass extends Observable {
 }
 declare namespace ConfigClass {
   export type _ = ConfigClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/AInstantiatesB.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/AInstantiatesB.ts
@@ -10,7 +10,7 @@ class AInstantiatesB extends Panel{
   declare readonly initialConfig: AInstantiatesB._;
 
   constructor(config:AInstantiatesB._ = null){
-    super( Exml.apply(new AInstantiatesB._({
+    super( Exml.apply(AInstantiatesB._({
 
   items:[
     new BDeclaresA({ someProperty: "yes"})
@@ -19,7 +19,7 @@ class AInstantiatesB extends Panel{
   }}
 declare namespace AInstantiatesB {
   export type _ = AInstantiatesB_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/DeclarationsMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/DeclarationsMxmlClass.ts
@@ -74,7 +74,7 @@ class DeclarationsMxmlClass extends SomeNativeClass{
   set other(value:SomeOtherClass) { this.#other = value; }}
 declare namespace DeclarationsMxmlClass {
   export type _ = DeclarationsMxmlClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/InterfaceImplementingMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/InterfaceImplementingMxmlClass.ts
@@ -14,7 +14,7 @@ class InterfaceImplementingMxmlClass extends ConfigClass implements YetAnotherIn
   declare readonly initialConfig: InterfaceImplementingMxmlClass._;
 
   constructor(config:InterfaceImplementingMxmlClass._ = null){
-    super( Exml.apply(new InterfaceImplementingMxmlClass._({
+    super( Exml.apply(InterfaceImplementingMxmlClass._({
 }),config));
   }
   #someProperty:string;
@@ -33,7 +33,7 @@ mixin(InterfaceImplementingMxmlClass, YetAnotherInterface);
 
 declare namespace InterfaceImplementingMxmlClass {
   export type _ = InterfaceImplementingMxmlClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataCdataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataCdataMxmlClass.ts
@@ -19,14 +19,14 @@ interface MetadataCdataMxmlClass_ extends ConfigClass._ {
  */
 class MetadataCdataMxmlClass extends ConfigClass{
   declare readonly initialConfig: MetadataCdataMxmlClass._;constructor(config:MetadataCdataMxmlClass._=null){
-    super( Exml.apply(new MetadataCdataMxmlClass._({
+    super( Exml.apply(MetadataCdataMxmlClass._({
 }),config));
 }}
 metadata(MetadataCdataMxmlClass, ["ThisIsJustATest"]);
 
 declare namespace MetadataCdataMxmlClass {
   export type _ = MetadataCdataMxmlClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/MetadataMxmlClass.ts
@@ -9,14 +9,14 @@ interface MetadataMxmlClass_ extends ConfigClass._ {
  */
 class MetadataMxmlClass extends ConfigClass{
   declare readonly initialConfig: MetadataMxmlClass._;constructor(config:MetadataMxmlClass._=null){
-    super( Exml.apply(new MetadataMxmlClass._({
+    super( Exml.apply(MetadataMxmlClass._({
 }),config));
 }}
 metadata(MetadataMxmlClass, ["ThisIsJustATest"]);
 
 declare namespace MetadataMxmlClass {
   export type _ = MetadataMxmlClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/ScriptCdataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/ScriptCdataMxmlClass.ts
@@ -22,7 +22,7 @@ class ScriptCdataMxmlClass extends ConfigClass implements SimpleInterface{
         throw "cannot do it with " + v;
       }
     }constructor(config:ScriptCdataMxmlClass._=null){
-    super( Exml.apply(new ScriptCdataMxmlClass._({
+    super( Exml.apply(ScriptCdataMxmlClass._({
              foo: "bar"
 }),config));
 }}
@@ -30,7 +30,7 @@ mixin(ScriptCdataMxmlClass, SimpleInterface);
 
 declare namespace ScriptCdataMxmlClass {
   export type _ = ScriptCdataMxmlClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMetadataMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMetadataMxmlClass.ts
@@ -7,14 +7,14 @@ interface SimpleMetadataMxmlClass_ extends ConfigClass._ {
 
 class SimpleMetadataMxmlClass extends ConfigClass{
   declare readonly initialConfig: SimpleMetadataMxmlClass._;constructor(config:SimpleMetadataMxmlClass._=null){
-    super( Exml.apply(new SimpleMetadataMxmlClass._({
+    super( Exml.apply(SimpleMetadataMxmlClass._({
 }),config));
 }}
 metadata(SimpleMetadataMxmlClass, ["ShortVersion"]);
 
 declare namespace SimpleMetadataMxmlClass {
   export type _ = SimpleMetadataMxmlClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMxmlClass.ts
@@ -60,7 +60,7 @@ class SimpleMxmlClass extends ConfigClass{
                           blubb_config: "blub config expression",
                           blubb_accessor: "blub accessor expression"})
     },config);
-    return  Exml.apply(new SimpleMxmlClass._({
+    return  Exml.apply(SimpleMxmlClass._({
              foo: "bar",
              number: 1 < 2  ? 1 + 1 : 3,
   defaultType: SomeOtherClass.xtype,
@@ -191,7 +191,7 @@ class SimpleMxmlClass extends ConfigClass{
   set no_config(value:SomeOtherClass) { this.#no_config = value; }}
 declare namespace SimpleMxmlClass {
   export type _ = SimpleMxmlClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/StringToArrayCoercion.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/StringToArrayCoercion.ts
@@ -7,13 +7,13 @@ interface StringToArrayCoercion_ {
 
 class StringToArrayCoercion extends Panel{
   declare readonly initialConfig: StringToArrayCoercion._;constructor(config:StringToArrayCoercion._=null){
-    super( Exml.apply(new StringToArrayCoercion._({
+    super( Exml.apply(StringToArrayCoercion._({
            items: ["just a joke"]
 }),config));
 }}
 declare namespace StringToArrayCoercion {
   export type _ = StringToArrayCoercion_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/StringToEmptyArrayCoercion.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/StringToEmptyArrayCoercion.ts
@@ -7,13 +7,13 @@ interface StringToEmptyArrayCoercion_ {
 
 class StringToEmptyArrayCoercion extends Panel{
   declare readonly initialConfig: StringToEmptyArrayCoercion._;constructor(config:StringToEmptyArrayCoercion._=null){
-    super( Exml.apply(new StringToEmptyArrayCoercion._({
+    super( Exml.apply(StringToEmptyArrayCoercion._({
   items:[]
 }),config));
 }}
 declare namespace StringToEmptyArrayCoercion {
   export type _ = StringToEmptyArrayCoercion_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/TestOldPropertyAccessSyntax.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/TestOldPropertyAccessSyntax.ts
@@ -21,7 +21,7 @@ class TestOldPropertyAccessSyntax extends Object{
   set foo(value:string) { this.#foo = value; }}
 declare namespace TestOldPropertyAccessSyntax {
   export type _ = TestOldPropertyAccessSyntax_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/WhitespaceAroundBindingExpression.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/WhitespaceAroundBindingExpression.ts
@@ -8,13 +8,13 @@ interface WhitespaceAroundBindingExpression_ {
 
 class WhitespaceAroundBindingExpression extends Panel{
   declare readonly initialConfig: WhitespaceAroundBindingExpression._;constructor(config:WhitespaceAroundBindingExpression._=null){
-    super( Exml.apply(new WhitespaceAroundBindingExpression._({
+    super( Exml.apply(WhitespaceAroundBindingExpression._({
   layout: new ContainerLayout()
 }),config));
 }}
 declare namespace WhitespaceAroundBindingExpression {
   export type _ = WhitespaceAroundBindingExpression_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/CyclicDependencies.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/CyclicDependencies.ts
@@ -19,7 +19,7 @@ class CyclicDependencies extends Object{
   set cause_trouble(value:CyclicDependencies_1) { this.#cause_trouble = value; }}
 declare namespace CyclicDependencies {
   export type _ = CyclicDependencies_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/PropertiesAccess.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/PropertiesAccess.ts
@@ -7,7 +7,7 @@ interface PropertiesAccess_ extends PropertiesAccessBase._ {
 
 class PropertiesAccess extends PropertiesAccessBase{
   declare readonly initialConfig: PropertiesAccess._;constructor(config:PropertiesAccess._=null){
-    super( Exml.apply(new PropertiesAccess._({
+    super( Exml.apply(PropertiesAccess._({
         property_1: "egal",
         property_2: "egaler",
         property_3: "am egalsten"
@@ -15,7 +15,7 @@ class PropertiesAccess extends PropertiesAccessBase{
 }}
 declare namespace PropertiesAccess {
   export type _ = PropertiesAccess_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/PropertiesAccessBase.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/PropertiesAccessBase.ts
@@ -32,7 +32,7 @@ class PropertiesAccessBase {
 }
 declare namespace PropertiesAccessBase {
   export type _ = PropertiesAccessBase_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/SimpleMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/SimpleMxmlClass.ts
@@ -15,14 +15,14 @@ class SimpleMxmlClass extends panel{
   static readonly xtype:string = "testNamespace.pkg.config.simpleMxmlClass";
 
   constructor(config:SimpleMxmlClass._ = null){
-    super( Exml.apply(new SimpleMxmlClass._({
+    super( Exml.apply(SimpleMxmlClass._({
         title:  package1_mxml_SimpleMxmlClass.xtype
 
 }),config));
   }}
 declare namespace SimpleMxmlClass {
   export type _ = SimpleMxmlClass_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponent.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponent.ts
@@ -16,7 +16,7 @@ class TestComponent extends TestComponentBase{
     config = Exml.apply({
     property_1: "withDefault"
     },config);
-    super( Exml.apply(new TestComponent._({
+    super( Exml.apply(TestComponent._({
         emptyText:  "<div class='widget-content-list-empty'>" + TestComponentBase.DEFAULT + "</div>",
         letters: [
               "a",
@@ -39,7 +39,7 @@ class TestComponent extends TestComponentBase{
   set property_2(value:int) { this.#property_2 = value; }}
 declare namespace TestComponent {
   export type _ = TestComponent_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponentBase.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/pkg/TestComponentBase.ts
@@ -37,7 +37,7 @@ mixin(TestComponentBase, TestInterface);
 
 declare namespace TestComponentBase {
   export type _ = TestComponentBase_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixin.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package2/TestMixin.ts
@@ -36,7 +36,7 @@ class TestMixin {
 }
 declare namespace TestMixin {
   export type _ = TestMixin_;
-  export const _: { new(config?: _): _; };
+  export const _: (config?: _) => _;
 }
 
 


### PR DESCRIPTION
Now that we evaluated Config Factory Functions as a superior programming model, it makes more sense to return to always creating Config objects by functions, not pretending to instantiate a non-existing class.
The change to classes was justified by problems in IDEs with declaration merging between a type and a function, which seemed to be mitigated by using the usual combination of type and object-with-constructor = class. But we could not reproduce these problems anymore.

Thus, the namespaced '_' value is now a factory function

    (config?: _) => _

instead of an object-with-constructor = (pseudo) class

    { new(config?: _): _; }

Constructing Config objects happens by applying the factory function

    SomeComponent._({ someConfig: someValue })

instead of instantiating the Config "class"

    new SomeComponent._({ someConfig: someValue })
