### PR TITLE
[TS] Ext pseudo-singletons are accessed via getInstance() in TS

### DIFF
--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptCodeGenerator.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptCodeGenerator.java
@@ -328,6 +328,14 @@ public class TypeScriptCodeGenerator extends CodeGeneratorBase {
               localName = TypeScriptModuleResolver.toLocalName(dependentPrimaryDeclaration.getQualifiedName());
             }
             moduleNameToLocalName.put(requireModuleName, localName);
+            // handle special pseudo-singletons that in Ext TS are accessed via getInstance():
+            Annotation nativeAnnotation = dependentPrimaryDeclaration.getAnnotation(Jooc.NATIVE_ANNOTATION_NAME);
+            if (nativeAnnotation != null) {
+              String requireValue = typeScriptModuleResolver.getNativeAnnotationRequireValue(nativeAnnotation);
+              if (requireValue != null && !requireValue.isEmpty()) {
+                localName += ".getInstance()";
+              }
+            }
           }
         }
       }

--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptModuleResolver.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptModuleResolver.java
@@ -111,10 +111,16 @@ public class TypeScriptModuleResolver extends ModuleResolverBase {
 
   private String getRequireModulePath(IdeDeclaration declaration) {
     Annotation nativeAnnotation = declaration.getAnnotation(Jooc.NATIVE_ANNOTATION_NAME);
-    if (nativeAnnotation != null && getNativeAnnotationRequireValue(nativeAnnotation) == null) {
-      return null;
+    String qualifiedName = "";
+    if (nativeAnnotation != null) {
+      qualifiedName = getNativeAnnotationRequireValue(nativeAnnotation);
+      if (qualifiedName == null) {
+        return null;
+      }
     }
-    String qualifiedName = declaration.getExtNamespaceRelativeTargetQualifiedNameStr();
+    if (qualifiedName.isEmpty()) {
+      qualifiedName = declaration.getExtNamespaceRelativeTargetQualifiedNameStr();
+    }
     // special case: In TypeScript, "AS3.Error" is directly mapped to native "Error":
     if ("AS3.Error".equals(qualifiedName)) {
       return null;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AllElements.js
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AllElements.js
@@ -163,10 +163,10 @@ Ext.define("package1.AllElements", function(AllElements) {/*public class AllElem
         "Ext.Action",
         "Ext.Button",
         "Ext.MenuItem",
-        "Ext.MessageBox",
         "Ext.events.PanelEvent",
         "Ext.mixin.SomeMixin",
         "Ext.plugins.APlugin",
+        "Ext.window.MessageBox",
         "exmlparser.config.allElements",
         "net.jangaroo.ext.Exml"
       ]

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AllElements.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/AllElements.ts
@@ -5,10 +5,10 @@ import uint from "../AS3/uint_";
 import Action from "../Ext/Action";
 import Button from "../Ext/Button";
 import MenuItem from "../Ext/MenuItem";
-import MessageBox from "../Ext/MessageBox";
 import Panel from "../Ext/Panel";
 import SomeMixin from "../Ext/mixin/SomeMixin";
 import APlugin from "../Ext/plugins/APlugin";
+import MessageBox from "../Ext/window/MessageBox";
 import allElements from "../exmlparser/config/allElements";
 import Exml from "../net/jangaroo/ext/Exml";
 interface AllElementsConfig extends Config<Panel>, Partial<Pick<AllElements,
@@ -82,7 +82,7 @@ class AllElements extends Panel{
     items:[
       Config(Button, { text: "Save",
         handler: ():void => 
-          MessageBox.alert("gotcha!")
+          MessageBox.getInstance().alert("gotcha!")
         
       }),
       {xtype: "editortreepanel"},

--- a/jangaroo/jangaroo-compiler/src/test/resources/ext/MessageBox.as
+++ b/jangaroo/jangaroo-compiler/src/test/resources/ext/MessageBox.as
@@ -1,7 +1,7 @@
 package ext {
+import ext.window.MessageBoxWindow;
 
-[Native("Ext.MessageBox", require)]
-public class MessageBox {
-  public native static function alert(msg:String):void;
-}
+[Native("Ext.MessageBox", require="Ext.window.MessageBox")]
+public const MessageBox: MessageBoxWindow;
+
 }

--- a/jangaroo/jangaroo-compiler/src/test/resources/ext/window/MessageBoxWindow.as
+++ b/jangaroo/jangaroo-compiler/src/test/resources/ext/window/MessageBoxWindow.as
@@ -1,0 +1,7 @@
+package ext.window {
+
+[Native("Ext.window.MessageBox", require)]
+public class MessageBoxWindow {
+  public native function alert(msg:String):void;
+}
+}


### PR DESCRIPTION
There are two special cases of Ext singletons that are actually created by requiring another (non-singleton) class: `Ext.MessageBox` (created by `Ext.window.MessageBox`) and `Ext.WindowManager` (created by `Ext.ZIndexManager`).
In Ext AS, these special cases are indicated by using the annotation
````
    [Native("<singleton>", require="<class>")]
````
In Ext TS, it is no longer possible to look up metadata of imported modules (well, only with tricks and effort), thus so far, these
two special cases were hard-wired in the Babel plugin.
To get rid of these special cases, we changed `ext-ts` to add static `getInstance()` methods to both `Ext.window.MessageBox` and `Ext.ZIndexManager` (API and runtime override).
The last piece of the puzzle is that the conversion compiler must rewrite access to the singleton to importing the corresponding class (derived from `require="..."`) and additionally call the `getInstance()` method when accessing the singleton.