### PR TITLE
[TS] Generate static class code blocks (ECMAScript proposal)

### DIFF
--- a/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptCodeGenerator.java
+++ b/jangaroo/jangaroo-compiler/src/main/java/net/jangaroo/jooc/backend/TypeScriptCodeGenerator.java
@@ -128,6 +128,7 @@ public class TypeScriptCodeGenerator extends CodeGeneratorBase {
   private boolean needsCompanionInterface;
   private List<ClassDeclaration> mixinClasses;
   private boolean hasOwnConfigClass;
+  private List<BlockStatement> staticCodeBlocks;
 
   TypeScriptCodeGenerator(TypeScriptModuleResolver typeScriptModuleResolver, JsWriter out, CompilationUnitResolver compilationUnitModelResolver) {
     super(out, compilationUnitModelResolver);
@@ -2131,7 +2132,15 @@ public class TypeScriptCodeGenerator extends CodeGeneratorBase {
         }
       }
     }
+    staticCodeBlocks = new ArrayList<>();
     super.visitClassBodyDirectives(classBodyDirectives);
+    if (!companionInterfaceMode) {
+      for (BlockStatement staticCodeBlock : staticCodeBlocks) {
+        out.writeSymbolWhitespace(staticCodeBlock.getSymbol());
+        out.writeToken("static ");
+        staticCodeBlock.visit(this);
+      }
+    }
   }
 
   private void generateRestResourceUriTemplateConstant(Annotation restResourceAnnotation) throws IOException {
@@ -2157,35 +2166,26 @@ public class TypeScriptCodeGenerator extends CodeGeneratorBase {
     }
   }
 
-  private int staticCodeCounter = 0;
-
   @Override
   void generateStaticInitializer(List<Directive> directives) throws IOException {
-    if (directives.isEmpty() || companionInterfaceMode) {
+    if (directives.isEmpty()) {
       return;
     }
     Directive firstDirective = directives.get(0);
-    out.writeSymbolWhitespace(firstDirective.getSymbol());
-    String uniqueName = "";
-    if (staticCodeCounter > 0) {
-      uniqueName = String.valueOf(staticCodeCounter);
-    }
-    ++staticCodeCounter;
-    out.writeToken(String.format("static #static%s = (() =>", uniqueName));
-
     // is static code already wrapped in a block?
     if (directives.size() == 1 && firstDirective instanceof BlockStatement) {
       // static block already has curly braces: reuse these!
-      firstDirective.visit(this);
+      staticCodeBlocks.add((BlockStatement) firstDirective);
     } else {
       // surround statements by curly braces:
-      out.writeToken(" {\n    ");
-      for (Directive directive : directives) {
-        directive.visit(this);
-      }
-      out.writeToken("\n  }");
+      JooSymbol firstSymbol = firstDirective.getSymbol();
+      JooSymbol lastSymbol = directives.get(directives.size() - 1).getSymbol();
+      staticCodeBlocks.add(new BlockStatement(
+              new JooSymbol(sym.LBRACE, firstSymbol.getFileName(), firstSymbol.getLine(), firstSymbol.getColumn(), firstSymbol.getWhitespace(), "{"),
+              directives,
+              new JooSymbol(sym.RBRACE, lastSymbol.getFileName(), lastSymbol.getLine(), lastSymbol.getColumn(), lastSymbol.getWhitespace(), "}")
+      ));
     }
-    out.writeToken(")();");
   }
 
   @Override

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/StaticAndNonStatic.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/StaticAndNonStatic.ts
@@ -5,14 +5,18 @@
  */
 class StaticAndNonStatic {
 
-  static #static = (() => {
-    new StaticAndNonStatic();
-  })();
-
   StaticAndNonStatic:string = null;
+
+  static {
+
+  new StaticAndNonStatic();
+
+  }
   
-  static #static1 = (() => {
-    new StaticAndNonStatic();
-  })();
+  static {
+  
+  new StaticAndNonStatic();
+  
+  }
 }
 export default StaticAndNonStatic;

--- a/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMxmlClass.ts
+++ b/jangaroo/jangaroo-compiler/src/test/resources/expected/package1/mxml/SimpleMxmlClass.ts
@@ -98,12 +98,6 @@ class SimpleMxmlClass extends ConfigClass{
 
   #blub:any;
 
-  static #static = (() =>{
-      if(1 < 0 && 0 > 1) {
-        throw "plain wrong!";
-      }
-    })();
-
   #list:any = null;
 
   get list():any { return this.#list; }
@@ -193,5 +187,11 @@ class SimpleMxmlClass extends ConfigClass{
   #no_config:SomeOtherClass = null;
 
   get no_config():SomeOtherClass { return this.#no_config; }
-  set no_config(value:SomeOtherClass) { this.#no_config = value; }}
+  set no_config(value:SomeOtherClass) { this.#no_config = value; }
+
+  static {
+      if(1 < 0 && 0 > 1) {
+        throw "plain wrong!";
+      }
+    }}
 export default SimpleMxmlClass;


### PR DESCRIPTION
ActionScript static class code was formerly represented in TypeScript by a static private member with a self-evaluating initializer.
Since version 4.4, TypeScript supports the ECMAScript proposal for static class code blocks.
We now use these to represent AS3 static class code. This simplifies the TypeScript output a bit, but we must move the static code block to the end of the class, as forward references to static members are not allowed in ECMAScript (but they were allowed in ActionScript).