### PR TITLE
4.1.9 preparations

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/WorkspaceConverterMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/WorkspaceConverterMojo.java
@@ -667,10 +667,10 @@ public class WorkspaceConverterMojo extends AbstractMojo {
   }
 
   private String renameLegacyProjectExtensionPoint(String projectExtensionPointName) {
-    if ("studio".equals(projectExtensionPointName)) {
-      return "studio-client";
-    } else if ("studio-dynamic".equals(projectExtensionPointName)) {
-      return "studio-client-dynamic";
+    if ("studio".equals(projectExtensionPointName) || "studio-client".equals(projectExtensionPointName)) {
+      return "studio-client.main-static";
+    } else if ("studio-dynamic".equals(projectExtensionPointName) || "studio-client-dynamic".equals(projectExtensionPointName)) {
+      return "studio-client.main";
     }
     return projectExtensionPointName;
   }

--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/WorkspaceConverterMojo.java
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/java/net/jangaroo/jooc/mvnplugin/WorkspaceConverterMojo.java
@@ -413,6 +413,7 @@ public class WorkspaceConverterMojo extends AbstractMojo {
       }
     } else if (moduleType == ModuleType.JANGAROO_APP) {
       jangarooConfig.setType("app");
+      setCommandMapEntry(jangarooConfig, "run", "proxyTargetUri", "http://localhost:41080");
       setCommandMapEntry(jangarooConfig, "run", "proxyPathSpec", "/rest/");
       jangarooConfig.setExtNamespace(extNamespace);
       jangarooConfig.setExtSassNamespace(extSassNamespace);
@@ -502,6 +503,7 @@ public class WorkspaceConverterMojo extends AbstractMojo {
       }
     } else if (moduleType == ModuleType.JANGAROO_APP_OVERLAY) {
       jangarooConfig.setType("app-overlay");
+      setCommandMapEntry(jangarooConfig, "run", "proxyTargetUri", "http://localhost:41080");
       setCommandMapEntry(jangarooConfig, "run", "proxyPathSpec", "/rest/");
 
       Map<String, String> devDependencies = new TreeMap<>();
@@ -518,6 +520,7 @@ public class WorkspaceConverterMojo extends AbstractMojo {
       additionalJsonEntries.setScripts(scripts);
     } else if (moduleType == ModuleType.JANGAROO_APPS) {
       jangarooConfig.setType("apps");
+      setCommandMapEntry(jangarooConfig, "run", "proxyTargetUri", "http://localhost:41080");
       setCommandMapEntry(jangarooConfig, "run", "proxyPathSpec", "/rest/");
       if (rootApp != null) {
         Package dependencyPackage = getDependencyPackageByRef(rootApp);


### PR DESCRIPTION
- renamed studio-client extension point to studio-client.main
- add default for "proxyTargetUri"
- use different conditional exports for typescript and js
