### PR TITLE
[TS] convert-workspace: pin major version of node and pnpm

### DIFF
--- a/jangaroo-maven/jangaroo-maven-plugin/src/main/resources/net/jangaroo/jooc/mvnplugin/package.json
+++ b/jangaroo-maven/jangaroo-maven-plugin/src/main/resources/net/jangaroo/jooc/mvnplugin/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0-SNAPSHOT",
   "private": true,
   "engines": {
-    "node": ">=16",
-    "pnpm": ">=6.14.6"
+    "node": "16",
+    "pnpm": "^6.14.6"
   },
   "devDependencies": {
     "@coremedia/set-version": "^1.1.1"


### PR DESCRIPTION
node must be version 16, not any newer major version,
and pnpm must be 6 (starting at 6.14.6 as before) and
not 7.